### PR TITLE
feat: upgrade to MCP Apps v0.4.1 with enhanced host context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+## [0.2.0] - 2025-01-16
+
+### Added - MCP Apps v0.4.1 Support
+
+#### Tool Visibility Filtering
+- Added `getToolVisibility(tool)` helper to extract visibility from `_meta.ui.visibility`
+- Added `isToolVisibleToModel(tool)` to check if tool should be sent to LLM
+- Tools with `visibility: ["app"]` are now hidden from the model/LLM tool list
+- App-only tools remain callable by apps via `tools/call`
+
+#### Enhanced Host Context (ui/initialize)
+- Host context now includes `theme` (dark/light detection)
+- Host context now includes `locale` (navigator.language)
+- Host context now includes `toolInfo` with name and arguments
+- Host context now includes `availableDisplayModes` (['inline', 'fullscreen'])
+- Host context now includes `styles.variables` with CSS custom properties
+
+#### Display Mode Support
+- Added `ui/requestDisplayMode` handler for fullscreen/pip/inline mode switching
+- Added CSS styles for `.display-mode-fullscreen`, `.display-mode-inline`, `.display-mode-pip`
+- Apps can request fullscreen mode (PiP falls back to inline for now)
+
+#### Model Context Support
+- Added `ui/modelContext` handler for apps to persist state to model context
+- Apps can send `content` and `structuredContent` to update context
+- Added `window.onModelContextUpdate` callback hook for integration
+
+#### Tool Cancellation Support
+- Added `ui/toolCancelled` notification capability
+- Each panel stores a `sendCancellation(reason)` method
+- Added `window.cancelMcpAppTool(serverName, uiResourceUri, reason)` global function
+- Added `window.cancelAllMcpAppTools(reason)` to cancel all active panels
+
+### Changed
+- Upgraded `@modelcontextprotocol/ext-apps` from `^0.3.1` to `^0.4.1`
+- Web UI now always uses multi-server mode (required for built-in tool-manager)
+- Updated host version to `0.2.0` in ui/initialize response
+
+### Fixed
+- Tool-manager now works correctly in single-server configurations
+
+### Files Modified
+- `package.json` - Version bump and ext-apps upgrade
+- `src/capabilities/apps.ts` - Added visibility helpers
+- `src/web/routes.ts` - Added visibility filtering, always use multi-server mode
+- `src/web/static/app.js` - Added v0.4.1 message handlers
+- `src/web/static/styles.css` - Added display mode CSS

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ai-sdk/anthropic": "^3.0.9",
         "@ai-sdk/openai": "^3.0.0",
         "@anthropic-ai/sdk": "^0.71.0",
-        "@modelcontextprotocol/ext-apps": "^0.3.1",
+        "@modelcontextprotocol/ext-apps": "^0.4.1",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@radix-ui/react-collapsible": "^1.1.0",
         "@radix-ui/react-dialog": "^1.1.0",
@@ -1201,9 +1201,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/ext-apps": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-0.3.1.tgz",
-      "integrity": "sha512-Iivz2KwWK8xlRbiWwFB/C4NXqE8VJBoRCbBkJCN98ST2UbQvA6kfyebcLsypiqylJS467XOOaBcI9DeQ3t+zqA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-0.4.1.tgz",
+      "integrity": "sha512-LUw6NidwWInzWVF8OSPw/Mtdz5ES2qF+yBze2h+WRARdSbXf+agTkZLCGFtdkogI64W6mDlJnSTp/k5W+FZ84A==",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-skilljack-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A full-capability MCP client demonstrating all advanced protocol features",
   "type": "module",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "@ai-sdk/anthropic": "^3.0.9",
     "@ai-sdk/openai": "^3.0.0",
     "@anthropic-ai/sdk": "^0.71.0",
-    "@modelcontextprotocol/ext-apps": "^0.3.1",
+    "@modelcontextprotocol/ext-apps": "^0.4.1",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.0",

--- a/src/capabilities/apps.ts
+++ b/src/capabilities/apps.ts
@@ -102,3 +102,32 @@ export async function getToolsWithUIInfo(client: Client): Promise<ToolWithUIInfo
     };
   });
 }
+
+/**
+ * Tool visibility targets (v0.4.1)
+ * - 'model': visible to LLM for AI-initiated tool calls
+ * - 'app': visible to apps for app-initiated tool calls via tools/call
+ */
+export type ToolVisibility = 'model' | 'app';
+
+/**
+ * Get the visibility settings for a tool.
+ * Tools can specify visibility in _meta.ui.visibility array.
+ * Default: visible to both model and app.
+ */
+export function getToolVisibility(tool: Tool): ToolVisibility[] {
+  const meta = tool._meta as { ui?: { visibility?: string[] } } | undefined;
+  const visibility = meta?.ui?.visibility;
+  if (Array.isArray(visibility) && visibility.length > 0) {
+    return visibility.filter((v): v is ToolVisibility => v === 'model' || v === 'app');
+  }
+  return ['model', 'app']; // default: visible to both
+}
+
+/**
+ * Check if a tool should be visible to the LLM/model.
+ * Tools with visibility: ["app"] are hidden from the model.
+ */
+export function isToolVisibleToModel(tool: Tool): boolean {
+  return getToolVisibility(tool).includes('model');
+}

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -367,3 +367,38 @@ header h1 {
   background: rgba(255, 107, 107, 0.1);
   border-radius: 4px;
 }
+
+/* ============ DISPLAY MODES (v0.4.1) ============ */
+
+/* Fullscreen display mode */
+.app-panel.display-mode-fullscreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9999;
+  border-radius: 0;
+  border: none;
+  min-height: 100vh;
+  max-height: 100vh;
+}
+
+.app-panel.display-mode-fullscreen .panel-header {
+  background: var(--bg);
+  padding: 0.5rem 1rem;
+}
+
+.app-panel.display-mode-fullscreen .panel-close {
+  font-size: 1.5rem;
+}
+
+/* Inline display mode (default) */
+.app-panel.display-mode-inline {
+  /* Default styling - no special changes needed */
+}
+
+/* PiP display mode (picture-in-picture) - reserved for future */
+.app-panel.display-mode-pip {
+  /* PiP mode not fully supported yet, behaves like inline */
+}


### PR DESCRIPTION
## Summary

- Upgrade `@modelcontextprotocol/ext-apps` from v0.3.1 to v0.4.1
- Add tool visibility filtering so app-only tools are hidden from LLM
- Add enhanced `hostContext` in `ui/initialize` response (theme, locale, toolInfo, availableDisplayModes, styles)
- Add `ui/requestDisplayMode` handler for fullscreen/pip/inline mode switching
- Add `ui/modelContext` handler for apps to persist state to model context
- Add `ui/toolCancelled` notification support for tool cancellation
- Always use multi-server mode in web UI (required for built-in tool-manager)

## Test plan

- [x] Build passes (`npm run build`)
- [x] Client connects to MCP Apps server (basic-vanillajs)
- [x] Tool-manager built-in app loads correctly
- [x] MCP Apps render and receive enhanced hostContext
- [ ] Test display mode switching (fullscreen)
- [ ] Test model context updates from app

🦉 Generated with [Claude Code](https://claude.com/claude-code)