### PR TITLE
feat: Server Config UI and Multi-Turn Tool Workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ npm-debug.log*
 *.swp
 *.swo
 
+# Claude Code local settings
+.claude/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/packages/mcp-server-manager/src/core/server-lifecycle.ts
+++ b/packages/mcp-server-manager/src/core/server-lifecycle.ts
@@ -104,7 +104,8 @@ export class ServerLifecycle extends EventEmitter {
    * Starts the server connection
    */
   async start(): Promise<void> {
-    if (this.state.status !== 'disconnected' && this.state.status !== 'failed') {
+    // Allow starting from disconnected, failed, or stopped states
+    if (this.state.status !== 'disconnected' && this.state.status !== 'failed' && this.state.status !== 'stopped') {
       this.logger.warn('Cannot start server in current state', {
         status: this.state.status,
       });

--- a/src/communication/http-adapter.ts
+++ b/src/communication/http-adapter.ts
@@ -164,6 +164,51 @@ export function createHTTPAdapter(options: AdapterOptions = {}): CommunicationAd
     },
 
     // ============================================
+    // Server Configuration
+    // ============================================
+
+    async getServerConfigs(): Promise<import('../shared/types.js').ServerConfigWithStatus[]> {
+      const data = await fetchJSON<{ servers: import('../shared/types.js').ServerConfigWithStatus[] }>(
+        '/api/server-config/servers'
+      );
+      return data.servers || [];
+    },
+
+    async addServerConfig(config: {
+      name: string;
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+    }): Promise<{ success: boolean }> {
+      return fetchJSON<{ success: boolean }>('/api/server-config/servers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      });
+    },
+
+    async updateServerConfig(
+      name: string,
+      config: { command?: string; args?: string[]; env?: Record<string, string>; enabled?: boolean }
+    ): Promise<{ success: boolean }> {
+      return fetchJSON<{ success: boolean }>(
+        `/api/server-config/servers/${encodeURIComponent(name)}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(config),
+        }
+      );
+    },
+
+    async removeServerConfig(name: string): Promise<{ success: boolean }> {
+      return fetchJSON<{ success: boolean }>(
+        `/api/server-config/servers/${encodeURIComponent(name)}`,
+        { method: 'DELETE' }
+      );
+    },
+
+    // ============================================
     // Resources
     // ============================================
 

--- a/src/communication/ipc-adapter.ts
+++ b/src/communication/ipc-adapter.ts
@@ -135,6 +135,35 @@ export function createIPCAdapter(electronAPI: ElectronAPI): CommunicationAdapter
     },
 
     // ============================================
+    // Server Configuration
+    // ============================================
+
+    async getServerConfigs() {
+      const data = await electronAPI.getServerConfigs();
+      return data.servers || [];
+    },
+
+    async addServerConfig(config: {
+      name: string;
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+    }) {
+      return electronAPI.addServerConfig(config);
+    },
+
+    async updateServerConfig(
+      name: string,
+      config: { command?: string; args?: string[]; env?: Record<string, string>; enabled?: boolean }
+    ) {
+      return electronAPI.updateServerConfig(name, config);
+    },
+
+    async removeServerConfig(name: string) {
+      return electronAPI.removeServerConfig(name);
+    },
+
+    // ============================================
     // Resources
     // ============================================
 
@@ -241,6 +270,43 @@ export function createIPCAdapter(electronAPI: ElectronAPI): CommunicationAdapter
       cleanups.push(
         electronAPI.onConnectionError((data) => {
           handler({ type: 'connection_error', ...data });
+        })
+      );
+
+      // Lifecycle events
+      cleanups.push(
+        electronAPI.onServerStatusChanged((data) => {
+          handler({ type: 'server_status_changed', payload: data });
+        })
+      );
+
+      cleanups.push(
+        electronAPI.onServerHealthy((data) => {
+          handler({ type: 'server_healthy', payload: data });
+        })
+      );
+
+      cleanups.push(
+        electronAPI.onServerUnhealthy((data) => {
+          handler({ type: 'server_unhealthy', payload: data });
+        })
+      );
+
+      cleanups.push(
+        electronAPI.onServerCrashed((data) => {
+          handler({ type: 'server_crashed', payload: data });
+        })
+      );
+
+      cleanups.push(
+        electronAPI.onServerRestarting((data) => {
+          handler({ type: 'server_restarting', payload: data });
+        })
+      );
+
+      cleanups.push(
+        electronAPI.onManagerReady((data) => {
+          handler({ type: 'manager_ready', payload: data });
         })
       );
 

--- a/src/communication/types.ts
+++ b/src/communication/types.ts
@@ -18,6 +18,11 @@ import type {
   WebSocketEvent,
   WebConfig,
   ServerWithState,
+  ServerStatusChangedPayload,
+  ServerHealthPayload,
+  ServerCrashedPayload,
+  ServerRestartingPayload,
+  ManagerReadyPayload,
 } from '../shared/types.js';
 
 // ============================================
@@ -38,6 +43,20 @@ export interface CommunicationAdapter {
   setToolEnabled(name: string, enabled: boolean): Promise<{ name: string; enabled: boolean }>;
   getToolManagerServers(): Promise<ServerWithState[]>;
   setServerEnabled(name: string, enabled: boolean): Promise<{ name: string; enabled: boolean }>;
+
+  // Server Configuration
+  getServerConfigs(): Promise<import('../shared/types.js').ServerConfigWithStatus[]>;
+  addServerConfig(config: {
+    name: string;
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+  }): Promise<{ success: boolean }>;
+  updateServerConfig(
+    name: string,
+    config: { command?: string; args?: string[]; env?: Record<string, string>; enabled?: boolean }
+  ): Promise<{ success: boolean }>;
+  removeServerConfig(name: string): Promise<{ success: boolean }>;
 
   // Resources
   getResources(): Promise<ResourceInfo[]>;
@@ -109,6 +128,28 @@ export interface ElectronAPI {
   onServersChanged(callback: () => void): () => void;
   onResourceUpdated(callback: (data: { uri: string; serverName: string }) => void): () => void;
   onConnectionError(callback: (data: { serverName: string; error: string }) => void): () => void;
+
+  // Lifecycle Events
+  onServerStatusChanged(callback: (data: ServerStatusChangedPayload) => void): () => void;
+  onServerHealthy(callback: (data: ServerHealthPayload) => void): () => void;
+  onServerUnhealthy(callback: (data: ServerHealthPayload) => void): () => void;
+  onServerCrashed(callback: (data: ServerCrashedPayload) => void): () => void;
+  onServerRestarting(callback: (data: ServerRestartingPayload) => void): () => void;
+  onManagerReady(callback: (data: ManagerReadyPayload) => void): () => void;
+
+  // Server Configuration
+  getServerConfigs(): Promise<{ servers: import('../shared/types.js').ServerConfigWithStatus[] }>;
+  addServerConfig(config: {
+    name: string;
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+  }): Promise<{ success: boolean }>;
+  updateServerConfig(
+    name: string,
+    config: { command?: string; args?: string[]; env?: Record<string, string>; enabled?: boolean }
+  ): Promise<{ success: boolean }>;
+  removeServerConfig(name: string): Promise<{ success: boolean }>;
 
   // Settings
   getSettings<T>(): Promise<T>;

--- a/src/electron/main/index.ts
+++ b/src/electron/main/index.ts
@@ -70,6 +70,21 @@ const createWindow = async (): Promise<void> => {
   // Show window when ready to prevent visual flash
   mainWindow.once('ready-to-show', () => {
     mainWindow?.show();
+    const focusApp = () => {
+      mainWindow?.focus();
+      mainWindow?.webContents.focus();
+      // Focus the chat input element
+      mainWindow?.webContents.executeJavaScript(
+        `document.querySelector('.chat-input')?.focus()`
+      );
+    };
+    if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+      // Dev mode: focus after DevTools has opened
+      setTimeout(focusApp, 500);
+    } else {
+      // Production: focus immediately
+      focusApp();
+    }
   });
 
   // Clean up on close

--- a/src/electron/main/ipc-handlers.ts
+++ b/src/electron/main/ipc-handlers.ts
@@ -299,6 +299,63 @@ export function setupIPCHandlers(
     }
   });
 
+  // ============================================
+  // Server Configuration
+  // ============================================
+
+  ipcMain.handle(channels.GET_SERVER_CONFIGS, async () => {
+    try {
+      const servers = await serverManager.getServerConfigs();
+      return { servers };
+    } catch (error) {
+      log.error('GET_SERVER_CONFIGS error:', error);
+      throw error;
+    }
+  });
+
+  ipcMain.handle(
+    channels.ADD_SERVER_CONFIG,
+    async (
+      _event,
+      config: { name: string; command: string; args?: string[]; env?: Record<string, string> }
+    ) => {
+      try {
+        await serverManager.addServerConfig(config);
+        return { success: true };
+      } catch (error) {
+        log.error('ADD_SERVER_CONFIG error:', error);
+        throw error;
+      }
+    }
+  );
+
+  ipcMain.handle(
+    channels.UPDATE_SERVER_CONFIG,
+    async (
+      _event,
+      name: string,
+      config: { command?: string; args?: string[]; env?: Record<string, string>; enabled?: boolean }
+    ) => {
+      try {
+        await serverManager.updateServerConfig(name, config);
+        return { success: true };
+      } catch (error) {
+        log.error('UPDATE_SERVER_CONFIG error:', error);
+        throw error;
+      }
+    }
+  );
+
+  ipcMain.handle(channels.REMOVE_SERVER_CONFIG, async (_event, name: string) => {
+    try {
+      await serverManager.removeServerConfig(name);
+      return { success: true };
+    } catch (error) {
+      log.error('REMOVE_SERVER_CONFIG error:', error);
+      throw error;
+    }
+  });
+
   log.info('IPC handlers registered');
 }
 

--- a/src/electron/main/mcp-manager.ts
+++ b/src/electron/main/mcp-manager.ts
@@ -280,6 +280,42 @@ const SERVER_START_TOOL: ToolWithUIInfo = {
   serverName: 'server-config',
 };
 
+const SERVER_ENABLE_TOOL: ToolWithUIInfo = {
+  name: 'server-config__enable-server',
+  displayName: 'enable-server',
+  description: 'Enable a disabled MCP server. When enabled, the server\'s tools become available for use.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        description: 'Name of the server to enable',
+      },
+    },
+    required: ['name'],
+  },
+  hasUi: false,
+  serverName: 'server-config',
+};
+
+const SERVER_DISABLE_TOOL: ToolWithUIInfo = {
+  name: 'server-config__disable-server',
+  displayName: 'disable-server',
+  description: 'Disable an MCP server. When disabled, the server\'s tools will not be available for use.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        description: 'Name of the server to disable',
+      },
+    },
+    required: ['name'],
+  },
+  hasUi: false,
+  serverName: 'server-config',
+};
+
 // All server-config action tools
 const SERVER_CONFIG_ACTION_TOOLS: ToolWithUIInfo[] = [
   SERVER_LIST_TOOL,
@@ -288,6 +324,8 @@ const SERVER_CONFIG_ACTION_TOOLS: ToolWithUIInfo[] = [
   SERVER_RESTART_TOOL,
   SERVER_STOP_TOOL,
   SERVER_START_TOOL,
+  SERVER_ENABLE_TOOL,
+  SERVER_DISABLE_TOOL,
 ];
 
 // ============================================
@@ -663,6 +701,54 @@ export class McpManager {
       } catch (err) {
         return {
           content: [{ type: 'text', text: `Failed to start server: ${err instanceof Error ? err.message : 'Unknown error'}` }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
+    }
+
+    if (name === 'server-config__enable-server') {
+      const { name: serverName } = args as { name: string };
+      if (!serverName) {
+        return {
+          content: [{ type: 'text', text: 'Missing required parameter: name' }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
+      try {
+        this.setServerEnabled(serverName, true);
+        return {
+          content: [{ type: 'text', text: `Server "${serverName}" has been enabled. Its tools are now available.` }],
+          serverName: 'server-config',
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Failed to enable server: ${err instanceof Error ? err.message : 'Unknown error'}` }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
+    }
+
+    if (name === 'server-config__disable-server') {
+      const { name: serverName } = args as { name: string };
+      if (!serverName) {
+        return {
+          content: [{ type: 'text', text: 'Missing required parameter: name' }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
+      try {
+        this.setServerEnabled(serverName, false);
+        return {
+          content: [{ type: 'text', text: `Server "${serverName}" has been disabled. Its tools are no longer available.` }],
+          serverName: 'server-config',
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Failed to disable server: ${err instanceof Error ? err.message : 'Unknown error'}` }],
           serverName: 'server-config',
           isError: true,
         };

--- a/src/electron/main/mcp-manager.ts
+++ b/src/electron/main/mcp-manager.ts
@@ -12,7 +12,7 @@
 import { app, BrowserWindow } from 'electron';
 import Store from 'electron-store';
 import log from 'electron-log';
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 import {
@@ -46,6 +46,8 @@ import type {
   PromptInfo,
   WebConfig,
   ServerWithState,
+  ServerConfigEntry,
+  ServerConfigWithStatus,
 } from '../../shared/types.js';
 
 // ============================================
@@ -142,11 +144,151 @@ class ToolManagerState {
 const TOOL_MANAGER_TOOL: ToolWithUIInfo = {
   name: 'tool-manager__manage-tools',
   displayName: 'manage-tools',
-  description: 'View and enable/disable tools from connected MCP servers',
+  description: 'SHOW or DISPLAY the tool manager UI. Use when user wants to SEE, VIEW, or SHOW available tools. Opens a visual panel to browse and toggle tools on/off.',
   hasUi: true,
   uiResourceUri: 'builtin://tool-manager',
   serverName: 'tool-manager',
 };
+
+const SERVER_CONFIG_TOOL: ToolWithUIInfo = {
+  name: 'server-config__configure-servers',
+  displayName: 'configure-servers',
+  description: 'SHOW or DISPLAY the server configuration UI. Use when user wants to SEE, VIEW, or SHOW server connections. Opens a visual panel to manage servers.',
+  hasUi: true,
+  uiResourceUri: 'builtin://server-config',
+  serverName: 'server-config',
+};
+
+// ============================================
+// Server Config Action Tools (no UI, direct actions)
+// ============================================
+
+const SERVER_LIST_TOOL: ToolWithUIInfo = {
+  name: 'server-config__list-servers',
+  displayName: 'list-servers',
+  description: 'Get server status as text data. Use for checking connection status programmatically. If user wants to SEE/SHOW/VIEW servers visually, use configure-servers instead.',
+  inputSchema: {
+    type: 'object',
+    properties: {},
+    required: [],
+  },
+  hasUi: false,
+  serverName: 'server-config',
+};
+
+const SERVER_ADD_TOOL: ToolWithUIInfo = {
+  name: 'server-config__add-server',
+  displayName: 'add-server',
+  description: 'Add a new MCP server connection. The server will be started automatically after adding.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        description: 'Unique name for the server (e.g., "filesystem", "github")',
+      },
+      command: {
+        type: 'string',
+        description: 'Command to run (e.g., "npx", "node", "python")',
+      },
+      args: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Command arguments (e.g., ["-y", "@modelcontextprotocol/server-filesystem", "/home"])',
+      },
+      env: {
+        type: 'object',
+        additionalProperties: { type: 'string' },
+        description: 'Environment variables (e.g., {"GITHUB_TOKEN": "..."})',
+      },
+    },
+    required: ['name', 'command'],
+  },
+  hasUi: false,
+  serverName: 'server-config',
+};
+
+const SERVER_REMOVE_TOOL: ToolWithUIInfo = {
+  name: 'server-config__remove-server',
+  displayName: 'remove-server',
+  description: 'Remove an MCP server from the configuration. The server will be disconnected.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        description: 'Name of the server to remove',
+      },
+    },
+    required: ['name'],
+  },
+  hasUi: false,
+  serverName: 'server-config',
+};
+
+const SERVER_RESTART_TOOL: ToolWithUIInfo = {
+  name: 'server-config__restart-server',
+  displayName: 'restart-server',
+  description: 'Restart an MCP server. Useful when a server becomes unresponsive or after configuration changes.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        description: 'Name of the server to restart',
+      },
+    },
+    required: ['name'],
+  },
+  hasUi: false,
+  serverName: 'server-config',
+};
+
+const SERVER_STOP_TOOL: ToolWithUIInfo = {
+  name: 'server-config__stop-server',
+  displayName: 'stop-server',
+  description: 'Stop a running MCP server. The server can be started again later.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        description: 'Name of the server to stop',
+      },
+    },
+    required: ['name'],
+  },
+  hasUi: false,
+  serverName: 'server-config',
+};
+
+const SERVER_START_TOOL: ToolWithUIInfo = {
+  name: 'server-config__start-server',
+  displayName: 'start-server',
+  description: 'Start a stopped MCP server.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        description: 'Name of the server to start',
+      },
+    },
+    required: ['name'],
+  },
+  hasUi: false,
+  serverName: 'server-config',
+};
+
+// All server-config action tools
+const SERVER_CONFIG_ACTION_TOOLS: ToolWithUIInfo[] = [
+  SERVER_LIST_TOOL,
+  SERVER_ADD_TOOL,
+  SERVER_REMOVE_TOOL,
+  SERVER_RESTART_TOOL,
+  SERVER_STOP_TOOL,
+  SERVER_START_TOOL,
+];
 
 // ============================================
 // MCP Manager Class
@@ -359,8 +501,13 @@ export class McpManager {
       toolsWithUI = toolsWithUI.filter((t) => t.hasUi);
     }
 
-    // Add tool-manager and filter disabled tools
-    return [TOOL_MANAGER_TOOL, ...this.toolState.filterEnabledTools(toolsWithUI)];
+    // Add built-in tools and filter disabled tools
+    return [
+      TOOL_MANAGER_TOOL,
+      SERVER_CONFIG_TOOL,
+      ...SERVER_CONFIG_ACTION_TOOLS,
+      ...this.toolState.filterEnabledTools(toolsWithUI),
+    ];
   }
 
   async callTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult> {
@@ -370,6 +517,121 @@ export class McpManager {
         content: [{ type: 'text', text: 'Tool manager opened.' }],
         serverName: 'tool-manager',
       };
+    }
+
+    // Handle built-in server-config
+    if (name === 'server-config__configure-servers') {
+      return {
+        content: [{ type: 'text', text: 'Server configuration opened.' }],
+        serverName: 'server-config',
+      };
+    }
+
+    // Handle server-config action tools
+    if (name === 'server-config__list-servers') {
+      const servers = await this.getServerConfigs();
+      const summary = servers.map(s =>
+        `- **${s.name}**: ${s.status} (${s.toolCount} tools)${s.lastError ? ` - Error: ${s.lastError}` : ''}`
+      ).join('\n');
+      return {
+        content: [{
+          type: 'text',
+          text: servers.length > 0
+            ? `## Connected Servers\n\n${summary}`
+            : 'No servers configured. Use add-server to add one.'
+        }],
+        serverName: 'server-config',
+      };
+    }
+
+    if (name === 'server-config__add-server') {
+      const { name: serverName, command, args: serverArgs, env } = args as {
+        name: string;
+        command: string;
+        args?: string[];
+        env?: Record<string, string>;
+      };
+      try {
+        await this.addServerConfig({ name: serverName, command, args: serverArgs, env });
+        return {
+          content: [{ type: 'text', text: `Server "${serverName}" added and starting...` }],
+          serverName: 'server-config',
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Failed to add server: ${err instanceof Error ? err.message : 'Unknown error'}` }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
+    }
+
+    if (name === 'server-config__remove-server') {
+      const { name: serverName } = args as { name: string };
+      try {
+        await this.removeServerConfig(serverName);
+        return {
+          content: [{ type: 'text', text: `Server "${serverName}" removed.` }],
+          serverName: 'server-config',
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Failed to remove server: ${err instanceof Error ? err.message : 'Unknown error'}` }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
+    }
+
+    if (name === 'server-config__restart-server') {
+      const { name: serverName } = args as { name: string };
+      try {
+        await this.restartServer(serverName);
+        return {
+          content: [{ type: 'text', text: `Server "${serverName}" is restarting...` }],
+          serverName: 'server-config',
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Failed to restart server: ${err instanceof Error ? err.message : 'Unknown error'}` }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
+    }
+
+    if (name === 'server-config__stop-server') {
+      const { name: serverName } = args as { name: string };
+      try {
+        await this.stopServer(serverName);
+        return {
+          content: [{ type: 'text', text: `Server "${serverName}" stopped.` }],
+          serverName: 'server-config',
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Failed to stop server: ${err instanceof Error ? err.message : 'Unknown error'}` }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
+    }
+
+    if (name === 'server-config__start-server') {
+      const { name: serverName } = args as { name: string };
+      try {
+        await this.startServer(serverName);
+        return {
+          content: [{ type: 'text', text: `Server "${serverName}" starting...` }],
+          serverName: 'server-config',
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Failed to start server: ${err instanceof Error ? err.message : 'Unknown error'}` }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
     }
 
     const clients = this.lifecycleManager?.getConnectedClients() ?? new Map();
@@ -481,6 +743,41 @@ export class McpManager {
       }
     }
 
+    // Handle built-in server-config UI
+    if (serverName === 'server-config' && uri === 'builtin://server-config') {
+      try {
+        const appPath = app.getAppPath();
+        const possiblePaths = [
+          // Development: relative to app root
+          join(appPath, 'src/web/static/server-config/mcp-app.html'),
+          // Production: in resources folder
+          join(appPath, 'resources/server-config/mcp-app.html'),
+          // Fallback: relative to __dirname
+          join(__dirname, '../../web/static/server-config/mcp-app.html'),
+          join(__dirname, '../../../src/web/static/server-config/mcp-app.html'),
+        ];
+
+        for (const htmlPath of possiblePaths) {
+          if (existsSync(htmlPath)) {
+            const html = await readFile(htmlPath, 'utf-8');
+            log.info('[McpManager] Loaded server-config UI from:', htmlPath);
+            return {
+              uri,
+              mimeType: 'text/html;mcp-app',
+              text: html,
+              serverName: 'server-config',
+            };
+          }
+        }
+
+        log.warn('[McpManager] Server-config UI not found. Tried paths:', possiblePaths);
+        return null;
+      } catch (err) {
+        log.error('[McpManager] Failed to load server-config UI:', err);
+        return null;
+      }
+    }
+
     const clients = this.lifecycleManager?.getConnectedClients() ?? new Map();
     const client = clients.get(serverName);
     if (!client) {
@@ -512,6 +809,177 @@ export class McpManager {
       arguments: p.arguments,
       serverName: p.serverName,
     }));
+  }
+
+  // ============================================
+  // Server Configuration
+  // ============================================
+
+  /**
+   * Get all server configurations with their current status
+   */
+  async getServerConfigs(): Promise<ServerConfigWithStatus[]> {
+    const configPath = store.get('configPath');
+    if (!configPath || !existsSync(configPath)) {
+      return [];
+    }
+
+    try {
+      const content = await readFile(configPath, 'utf-8');
+      const config = JSON.parse(content) as { mcpServers?: Record<string, unknown> };
+      const servers = config.mcpServers || {};
+      const states = this.lifecycleManager?.getAllServerStates() ?? [];
+      const serverSummary = await this.getServers();
+
+      return Object.entries(servers).map(([name, serverConfig]) => {
+        const cfg = serverConfig as { command?: string; args?: string[]; env?: Record<string, string> };
+        const state = states.find((s) => s.name === name);
+        const summary = serverSummary.find((s) => s.name === name);
+
+        return {
+          name,
+          transport: 'stdio' as const,
+          command: cfg.command || '',
+          args: cfg.args,
+          env: cfg.env,
+          enabled: this.toolState.isServerEnabled(name),
+          status: state?.status ?? 'disconnected',
+          toolCount: summary?.toolCount ?? 0,
+          healthy: state?.healthy ?? false,
+          lastError: state?.error,
+        };
+      });
+    } catch (error) {
+      log.error('Failed to read server configs:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Add a new server to the configuration
+   */
+  async addServerConfig(config: {
+    name: string;
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+  }): Promise<void> {
+    const configPath = store.get('configPath');
+    if (!configPath) {
+      throw new Error('No configuration file path set');
+    }
+
+    // Read current config
+    let fileConfig: { mcpServers?: Record<string, unknown> } = { mcpServers: {} };
+    if (existsSync(configPath)) {
+      const content = await readFile(configPath, 'utf-8');
+      fileConfig = JSON.parse(content);
+    }
+
+    // Check for duplicate
+    if (fileConfig.mcpServers && fileConfig.mcpServers[config.name]) {
+      throw new Error(`Server '${config.name}' already exists`);
+    }
+
+    // Add new server
+    fileConfig.mcpServers = fileConfig.mcpServers || {};
+    fileConfig.mcpServers[config.name] = {
+      transport: 'stdio',
+      command: config.command,
+      args: config.args || [],
+      env: config.env,
+    };
+
+    // Write back
+    await writeFile(configPath, JSON.stringify(fileConfig, null, 2), 'utf-8');
+    log.info(`Added server config: ${config.name}`);
+
+    // Reload configuration to connect new server
+    await this.loadConfig(configPath);
+  }
+
+  /**
+   * Update an existing server configuration
+   */
+  async updateServerConfig(
+    name: string,
+    config: {
+      command?: string;
+      args?: string[];
+      env?: Record<string, string>;
+      enabled?: boolean;
+    }
+  ): Promise<void> {
+    const configPath = store.get('configPath');
+    if (!configPath || !existsSync(configPath)) {
+      throw new Error('No configuration file found');
+    }
+
+    // Handle enabled state separately (it's stored in electron-store, not servers.json)
+    if (config.enabled !== undefined) {
+      this.toolState.setServerEnabled(name, config.enabled);
+    }
+
+    // If only changing enabled state, no need to modify the config file
+    if (config.command === undefined && config.args === undefined && config.env === undefined) {
+      return;
+    }
+
+    // Read current config
+    const content = await readFile(configPath, 'utf-8');
+    const fileConfig = JSON.parse(content) as { mcpServers?: Record<string, unknown> };
+
+    if (!fileConfig.mcpServers || !fileConfig.mcpServers[name]) {
+      throw new Error(`Server '${name}' not found`);
+    }
+
+    const existing = fileConfig.mcpServers[name] as Record<string, unknown>;
+
+    // Update fields
+    if (config.command !== undefined) {
+      existing.command = config.command;
+    }
+    if (config.args !== undefined) {
+      existing.args = config.args;
+    }
+    if (config.env !== undefined) {
+      existing.env = config.env;
+    }
+
+    // Write back
+    await writeFile(configPath, JSON.stringify(fileConfig, null, 2), 'utf-8');
+    log.info(`Updated server config: ${name}`);
+
+    // Reload configuration to apply changes
+    await this.loadConfig(configPath);
+  }
+
+  /**
+   * Remove a server from the configuration
+   */
+  async removeServerConfig(name: string): Promise<void> {
+    const configPath = store.get('configPath');
+    if (!configPath || !existsSync(configPath)) {
+      throw new Error('No configuration file found');
+    }
+
+    // Read current config
+    const content = await readFile(configPath, 'utf-8');
+    const fileConfig = JSON.parse(content) as { mcpServers?: Record<string, unknown> };
+
+    if (!fileConfig.mcpServers || !fileConfig.mcpServers[name]) {
+      throw new Error(`Server '${name}' not found`);
+    }
+
+    // Remove server
+    delete fileConfig.mcpServers[name];
+
+    // Write back
+    await writeFile(configPath, JSON.stringify(fileConfig, null, 2), 'utf-8');
+    log.info(`Removed server config: ${name}`);
+
+    // Reload configuration
+    await this.loadConfig(configPath);
   }
 
   // ============================================

--- a/src/electron/main/mcp-manager.ts
+++ b/src/electron/main/mcp-manager.ts
@@ -468,7 +468,7 @@ export class McpManager {
       const state = states.find((st) => st.name === s.name);
       return {
         name: s.name,
-        version: s.serverVersion?.name,
+        version: s.serverVersion?.version,
         status: state?.status ?? 'disconnected',
         toolCount: s.toolCount,
         healthy: state?.healthy,
@@ -551,6 +551,13 @@ export class McpManager {
         args?: string[];
         env?: Record<string, string>;
       };
+      if (!serverName || !command) {
+        return {
+          content: [{ type: 'text', text: `Missing required parameter: ${!serverName ? 'name' : 'command'}` }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
       try {
         await this.addServerConfig({ name: serverName, command, args: serverArgs, env });
         return {
@@ -568,6 +575,13 @@ export class McpManager {
 
     if (name === 'server-config__remove-server') {
       const { name: serverName } = args as { name: string };
+      if (!serverName) {
+        return {
+          content: [{ type: 'text', text: 'Missing required parameter: name' }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
       try {
         await this.removeServerConfig(serverName);
         return {
@@ -585,6 +599,13 @@ export class McpManager {
 
     if (name === 'server-config__restart-server') {
       const { name: serverName } = args as { name: string };
+      if (!serverName) {
+        return {
+          content: [{ type: 'text', text: 'Missing required parameter: name' }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
       try {
         await this.restartServer(serverName);
         return {
@@ -602,6 +623,13 @@ export class McpManager {
 
     if (name === 'server-config__stop-server') {
       const { name: serverName } = args as { name: string };
+      if (!serverName) {
+        return {
+          content: [{ type: 'text', text: 'Missing required parameter: name' }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
       try {
         await this.stopServer(serverName);
         return {
@@ -619,6 +647,13 @@ export class McpManager {
 
     if (name === 'server-config__start-server') {
       const { name: serverName } = args as { name: string };
+      if (!serverName) {
+        return {
+          content: [{ type: 'text', text: 'Missing required parameter: name' }],
+          serverName: 'server-config',
+          isError: true,
+        };
+      }
       try {
         await this.startServer(serverName);
         return {

--- a/src/electron/preload/host.ts
+++ b/src/electron/preload/host.ts
@@ -254,6 +254,40 @@ const electronAPI = {
   },
 
   // ============================================
+  // Server Configuration
+  // ============================================
+
+  getServerConfigs: () => {
+    validateInvokeChannel(channels.GET_SERVER_CONFIGS);
+    return ipcRenderer.invoke(channels.GET_SERVER_CONFIGS);
+  },
+
+  addServerConfig: (config: {
+    name: string;
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+  }) => {
+    validateInvokeChannel(channels.ADD_SERVER_CONFIG);
+    return ipcRenderer.invoke(channels.ADD_SERVER_CONFIG, config);
+  },
+
+  updateServerConfig: (name: string, config: {
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    enabled?: boolean;
+  }) => {
+    validateInvokeChannel(channels.UPDATE_SERVER_CONFIG);
+    return ipcRenderer.invoke(channels.UPDATE_SERVER_CONFIG, name, config);
+  },
+
+  removeServerConfig: (name: string) => {
+    validateInvokeChannel(channels.REMOVE_SERVER_CONFIG);
+    return ipcRenderer.invoke(channels.REMOVE_SERVER_CONFIG, name);
+  },
+
+  // ============================================
   // Lifecycle Event Listeners
   // ============================================
 

--- a/src/renderer/chat/components/ChatInput.tsx
+++ b/src/renderer/chat/components/ChatInput.tsx
@@ -31,6 +31,27 @@ export function ChatInput() {
     }
   }, [state.isOpen]);
 
+  // Refocus textarea when processing completes
+  // Track previous processing state to detect completion transition
+  const wasProcessingRef = useRef(state.isProcessing);
+  useEffect(() => {
+    const wasProcessing = wasProcessingRef.current;
+    wasProcessingRef.current = state.isProcessing;
+
+    // Only refocus when transitioning from processing to not processing
+    // Note: Don't check state.isOpen because in Electron alwaysOpen mode it's false
+    if (wasProcessing && !state.isProcessing) {
+      // Use requestAnimationFrame + timeout to ensure we focus after React settles
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          if (textareaRef.current && document.activeElement !== textareaRef.current) {
+            textareaRef.current.focus();
+          }
+        }, 100);
+      });
+    }
+  }, [state.isProcessing]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       // Enter to send (without Shift)

--- a/src/renderer/chat/components/ChatInput.tsx
+++ b/src/renderer/chat/components/ChatInput.tsx
@@ -21,12 +21,21 @@ export function ChatInput() {
   const { state, setInput, sendMessage, navigateHistory } = useChat();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // Auto-focus textarea on mount (for Electron alwaysOpen mode)
+  // Auto-focus textarea on initial load
   useEffect(() => {
-    // Small delay to ensure app has fully rendered
-    setTimeout(() => {
-      textareaRef.current?.focus();
-    }, 100);
+    const focusInput = () => {
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+      });
+    };
+
+    // If document already loaded, focus now; otherwise wait for load
+    if (document.readyState === 'complete') {
+      focusInput();
+    } else {
+      window.addEventListener('load', focusInput);
+      return () => window.removeEventListener('load', focusInput);
+    }
   }, []);
 
   // Auto-focus textarea when drawer opens (for web mode)

--- a/src/renderer/chat/components/ChatInput.tsx
+++ b/src/renderer/chat/components/ChatInput.tsx
@@ -21,7 +21,15 @@ export function ChatInput() {
   const { state, setInput, sendMessage, navigateHistory } = useChat();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // Auto-focus textarea when drawer opens
+  // Auto-focus textarea on mount (for Electron alwaysOpen mode)
+  useEffect(() => {
+    // Small delay to ensure app has fully rendered
+    setTimeout(() => {
+      textareaRef.current?.focus();
+    }, 100);
+  }, []);
+
+  // Auto-focus textarea when drawer opens (for web mode)
   useEffect(() => {
     if (state.isOpen && textareaRef.current) {
       // Small delay to ensure drawer animation has started

--- a/src/renderer/chat/components/ServerStatus.tsx
+++ b/src/renderer/chat/components/ServerStatus.tsx
@@ -1,21 +1,99 @@
 /**
  * Server Status Component
  *
- * Displays connected MCP servers with status indicators.
+ * Displays connected MCP servers with lifecycle status indicators.
+ * Supports full lifecycle states: connected, connecting, disconnected,
+ * unhealthy, restarting, failed, stopped.
  */
 
 import * as Tooltip from '@radix-ui/react-tooltip';
-import type { ServerInfo } from '../types';
+import type { ServerInfo, ServerStatus as ServerStatusType } from '../types';
 
 interface ServerStatusProps {
   servers: ServerInfo[];
+}
+
+/**
+ * Get human-readable status label
+ */
+function getStatusLabel(status: ServerStatusType): string {
+  const labels: Record<ServerStatusType, string> = {
+    connected: 'Connected',
+    connecting: 'Connecting...',
+    disconnected: 'Disconnected',
+    unhealthy: 'Unhealthy',
+    restarting: 'Restarting...',
+    failed: 'Failed',
+    stopped: 'Stopped',
+  };
+  return labels[status] || status;
+}
+
+/**
+ * Build tooltip details based on server state
+ */
+function getTooltipDetails(server: ServerInfo): React.ReactNode[] {
+  const details: React.ReactNode[] = [];
+
+  // Version
+  if (server.version) {
+    details.push(
+      <div key="version" className="tooltip-detail">
+        Version: {server.version}
+      </div>
+    );
+  }
+
+  // Tool count
+  details.push(
+    <div key="tools" className="tooltip-detail">
+      Tools: {server.toolCount}
+    </div>
+  );
+
+  // Status with label
+  details.push(
+    <div key="status" className="tooltip-detail">
+      Status: {getStatusLabel(server.status)}
+    </div>
+  );
+
+  // Restart attempts (when restarting)
+  if (server.status === 'restarting' && server.restartAttempts !== undefined) {
+    const maxAttempts = server.maxRestartAttempts ?? 5;
+    details.push(
+      <div key="restart" className="tooltip-detail">
+        Restart attempt: {server.restartAttempts}/{maxAttempts}
+      </div>
+    );
+  }
+
+  // Health check failures (when unhealthy)
+  if (server.status === 'unhealthy' && server.healthChecksFailed !== undefined) {
+    details.push(
+      <div key="health" className="tooltip-detail">
+        Health checks failed: {server.healthChecksFailed}
+      </div>
+    );
+  }
+
+  // Last error (when failed or unhealthy)
+  if ((server.status === 'failed' || server.status === 'unhealthy') && server.lastError) {
+    details.push(
+      <div key="error" className="tooltip-detail tooltip-error">
+        Error: {server.lastError}
+      </div>
+    );
+  }
+
+  return details;
 }
 
 export function ServerStatus({ servers }: ServerStatusProps) {
   if (servers.length === 0) {
     return (
       <div className="server-status">
-        <span className="server-badge">
+        <span className="server-badge" data-status="connecting">
           <span className="server-badge-indicator" data-status="connecting" />
           <span>Connecting...</span>
         </span>
@@ -29,7 +107,7 @@ export function ServerStatus({ servers }: ServerStatusProps) {
         {servers.map((server) => (
           <Tooltip.Root key={server.name}>
             <Tooltip.Trigger asChild>
-              <span className="server-badge">
+              <span className="server-badge" data-status={server.status}>
                 <span
                   className="server-badge-indicator"
                   data-status={server.status}
@@ -40,15 +118,7 @@ export function ServerStatus({ servers }: ServerStatusProps) {
             <Tooltip.Portal>
               <Tooltip.Content className="tooltip-content" sideOffset={5}>
                 <div className="tooltip-title">{server.name}</div>
-                {server.version && (
-                  <div className="tooltip-detail">Version: {server.version}</div>
-                )}
-                <div className="tooltip-detail">
-                  Tools: {server.toolCount}
-                </div>
-                <div className="tooltip-detail">
-                  Status: {server.status}
-                </div>
+                {getTooltipDetails(server)}
                 <Tooltip.Arrow className="tooltip-arrow" />
               </Tooltip.Content>
             </Tooltip.Portal>

--- a/src/renderer/chat/components/ToolExecutor.tsx
+++ b/src/renderer/chat/components/ToolExecutor.tsx
@@ -2,6 +2,7 @@
  * Tool Executor Component
  *
  * Watches for pending tool calls and executes them.
+ * After tools complete, ChatContext's useEffect handles continuation for multi-turn workflows.
  * This is a "behavior" component - it doesn't render anything visible.
  */
 
@@ -32,12 +33,13 @@ export function ToolExecutor() {
 
       // Mark as executing and run
       executingRef.current.add(message.id);
-      console.log('[ToolExecutor] Executing tools for message:', message.id, pendingTools.map(t => t.name));
+      console.log('[ToolExecutor] Executing tools for message:', message.id, pendingTools.map(t => t.displayName));
 
       executeAllTools(message.id, pendingTools)
         .then((results) => {
           console.log('[ToolExecutor] Tools executed:', results);
           executingRef.current.delete(message.id);
+          // Note: Continuation is handled by ChatContext's useEffect that watches for completed tools
         })
         .catch((err) => {
           console.error('[ToolExecutor] Error executing tools:', err);

--- a/src/renderer/chat/context/ChatContext.tsx
+++ b/src/renderer/chat/context/ChatContext.tsx
@@ -712,6 +712,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
           originalName: t.displayName || t.name,
           serverName: t.serverName || 'default',
           description: t.description,
+          inputSchema: t.inputSchema,
           hasUi: t.hasUi,
           uiResourceUri: t.uiResourceUri,
         }));

--- a/src/renderer/chat/main.css
+++ b/src/renderer/chat/main.css
@@ -21,6 +21,7 @@
   --chat-string: #ce9178;
   --chat-success: #6a9955;
   --chat-warning: #dcdcaa;
+  --chat-info: #569cd6;
 
   /* Typography - Monospace */
   --chat-font: 'Fira Code', 'Cascadia Code', 'JetBrains Mono', 'SF Mono', 'Consolas', monospace;
@@ -497,11 +498,46 @@
   border-radius: 3px;
   background-color: #1e3a1e;
   color: var(--chat-prompt);
+  display: inline-flex;
+  align-items: center;
+  cursor: default;
 }
 
+/* Status-based badge backgrounds */
+.server-badge[data-status='connected'] {
+  background-color: #1e3a1e;
+  color: var(--chat-success);
+}
+
+.server-badge[data-status='connecting'] {
+  background-color: #1e2a3a;
+  color: var(--chat-info);
+}
+
+.server-badge[data-status='disconnected'] {
+  background-color: #2d2d2d;
+  color: var(--chat-text-muted);
+}
+
+.server-badge[data-status='unhealthy'] {
+  background-color: #3a3a1e;
+  color: var(--chat-warning);
+}
+
+.server-badge[data-status='restarting'] {
+  background-color: #1e2a3a;
+  color: var(--chat-info);
+}
+
+.server-badge[data-status='failed'],
 .server-badge[data-status='error'] {
   background-color: #3a1e1e;
   color: var(--chat-error);
+}
+
+.server-badge[data-status='stopped'] {
+  background-color: #2d2d2d;
+  color: var(--chat-text-muted);
 }
 
 .server-badge-indicator {
@@ -510,14 +546,90 @@
   height: 6px;
   border-radius: 50%;
   margin-right: var(--space-xs);
+  flex-shrink: 0;
 }
 
+/* Status-based indicator colors */
 .server-badge-indicator[data-status='connected'] {
   background-color: var(--chat-success);
 }
 
+.server-badge-indicator[data-status='connecting'] {
+  background-color: var(--chat-info);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.server-badge-indicator[data-status='disconnected'] {
+  background-color: var(--chat-text-muted);
+}
+
+.server-badge-indicator[data-status='unhealthy'] {
+  background-color: var(--chat-warning);
+}
+
+.server-badge-indicator[data-status='restarting'] {
+  background-color: var(--chat-info);
+  animation: pulse 1s ease-in-out infinite;
+}
+
+.server-badge-indicator[data-status='failed'],
 .server-badge-indicator[data-status='error'] {
   background-color: var(--chat-error);
+}
+
+.server-badge-indicator[data-status='stopped'] {
+  background-color: var(--chat-text-muted);
+}
+
+/* Pulse animation for connecting/restarting states */
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+/* ============================================
+   Server Status Tooltips
+   ============================================ */
+
+.tooltip-content {
+  background-color: var(--chat-bg-secondary);
+  border: 1px solid var(--chat-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm);
+  font-family: var(--chat-font);
+  font-size: var(--font-size-xs);
+  color: var(--chat-text);
+  max-width: 250px;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.tooltip-title {
+  font-weight: 600;
+  margin-bottom: var(--space-xs);
+  color: var(--chat-accent);
+}
+
+.tooltip-detail {
+  color: var(--chat-text-muted);
+  line-height: 1.4;
+}
+
+.tooltip-detail + .tooltip-detail {
+  margin-top: 2px;
+}
+
+.tooltip-error {
+  color: var(--chat-error);
+  word-break: break-word;
+}
+
+.tooltip-arrow {
+  fill: var(--chat-bg-secondary);
 }
 
 /* ============================================

--- a/src/renderer/chat/types/index.ts
+++ b/src/renderer/chat/types/index.ts
@@ -37,12 +37,35 @@ export interface ToolCallResult {
 // Server Types
 // ============================================
 
+/**
+ * Server lifecycle status values.
+ * Maps to ServerStatus from @skilljack/mcp-server-manager
+ */
+export type ServerStatus =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'unhealthy'
+  | 'restarting'
+  | 'failed'
+  | 'stopped';
+
 export interface ServerInfo {
   name: string;
   version?: string;
-  status: 'connected' | 'connecting' | 'error';
+  status: ServerStatus;
   toolCount: number;
   capabilities?: Record<string, unknown>;
+  /** Number of health checks passed (when healthy) */
+  healthChecksPassed?: number;
+  /** Number of consecutive health check failures */
+  healthChecksFailed?: number;
+  /** Current restart attempt number (when restarting) */
+  restartAttempts?: number;
+  /** Maximum restart attempts allowed */
+  maxRestartAttempts?: number;
+  /** Last error message (when failed/unhealthy) */
+  lastError?: string;
 }
 
 export interface McpTool {
@@ -93,6 +116,7 @@ export type ChatAction =
   | { type: 'SET_PROCESSING'; isProcessing: boolean }
   | { type: 'SET_STREAMING_MESSAGE'; id: string | null }
   | { type: 'SET_SERVERS'; servers: ServerInfo[] }
+  | { type: 'UPDATE_SERVER_STATUS'; serverName: string; updates: Partial<ServerInfo> }
   | { type: 'SET_TOOLS'; tools: McpTool[] }
   | { type: 'FILTER_SERVERS'; serverNames: string[] | null }
   | { type: 'SET_ERROR'; error: string | null }

--- a/src/renderer/chat/types/index.ts
+++ b/src/renderer/chat/types/index.ts
@@ -8,6 +8,16 @@
 // Message Types
 // ============================================
 
+/**
+ * Model configuration stored with assistant messages for continuation
+ */
+export interface MessageModelConfig {
+  provider: 'anthropic' | 'openai';
+  modelId: string;
+  temperature: number;
+  maxTurns: number;
+}
+
 export interface ChatMessage {
   id: string;
   role: 'user' | 'assistant' | 'system';
@@ -16,6 +26,8 @@ export interface ChatMessage {
   toolCalls?: ChatToolCall[];
   isStreaming?: boolean;
   error?: string;
+  /** Model config for assistant messages - used for multi-turn continuation */
+  modelConfig?: MessageModelConfig;
 }
 
 export interface ChatToolCall {
@@ -100,6 +112,8 @@ export interface ChatState {
   tools: McpTool[];
   activeServers: string[] | null;  // null = all servers
   error: string | null;
+  /** Current turn in multi-turn tool workflow (0 = first turn) */
+  currentTurn: number;
 }
 
 export type ChatAction =
@@ -112,6 +126,7 @@ export type ChatAction =
   | { type: 'ADD_MESSAGE'; message: ChatMessage }
   | { type: 'UPDATE_MESSAGE'; id: string; updates: Partial<ChatMessage> }
   | { type: 'APPEND_STREAM'; id: string; content: string }
+  | { type: 'APPEND_TOOL_CALLS'; messageId: string; toolCalls: ChatToolCall[] }
   | { type: 'UPDATE_TOOL_CALL'; messageId: string; toolCallId: string; updates: Partial<ChatToolCall> }
   | { type: 'SET_PROCESSING'; isProcessing: boolean }
   | { type: 'SET_STREAMING_MESSAGE'; id: string | null }
@@ -121,7 +136,9 @@ export type ChatAction =
   | { type: 'FILTER_SERVERS'; serverNames: string[] | null }
   | { type: 'SET_ERROR'; error: string | null }
   | { type: 'CLEAR_MESSAGES' }
-  | { type: 'NEW_SESSION' };
+  | { type: 'NEW_SESSION' }
+  | { type: 'INCREMENT_TURN' }
+  | { type: 'RESET_TURN' };
 
 // ============================================
 // Theme Types

--- a/src/renderer/mcp-apps/McpAppPanel.tsx
+++ b/src/renderer/mcp-apps/McpAppPanel.tsx
@@ -385,7 +385,11 @@ export function McpAppPanel({ panel, onClose, isActive = true }: McpAppPanelProp
         // Restart server
         if (data.method === 'server-config/restartServer' && data.id) {
           try {
-            const { name } = data.params;
+            const { name } = data.params || {};
+            if (!name) {
+              sendToApp(createJsonRpcError(data.id, -32602, 'Missing required parameter: name'));
+              return;
+            }
             // Note: restartServer is exposed through window.electronAPI but not through the adapter yet
             // For now, we'll use the direct electronAPI if available
             if (window.electronAPI && 'restartServer' in window.electronAPI) {
@@ -405,7 +409,11 @@ export function McpAppPanel({ panel, onClose, isActive = true }: McpAppPanelProp
         // Stop server
         if (data.method === 'server-config/stopServer' && data.id) {
           try {
-            const { name } = data.params;
+            const { name } = data.params || {};
+            if (!name) {
+              sendToApp(createJsonRpcError(data.id, -32602, 'Missing required parameter: name'));
+              return;
+            }
             if (window.electronAPI && 'stopServer' in window.electronAPI) {
               await (window.electronAPI as { stopServer: (name: string) => Promise<void> }).stopServer(name);
               sendToApp(createJsonRpcResponse(data.id, { success: true }));
@@ -423,7 +431,11 @@ export function McpAppPanel({ panel, onClose, isActive = true }: McpAppPanelProp
         // Start server
         if (data.method === 'server-config/startServer' && data.id) {
           try {
-            const { name } = data.params;
+            const { name } = data.params || {};
+            if (!name) {
+              sendToApp(createJsonRpcError(data.id, -32602, 'Missing required parameter: name'));
+              return;
+            }
             if (window.electronAPI && 'startServer' in window.electronAPI) {
               await (window.electronAPI as { startServer: (name: string) => Promise<void> }).startServer(name);
               sendToApp(createJsonRpcResponse(data.id, { success: true }));

--- a/src/renderer/mcp-apps/McpAppPanel.tsx
+++ b/src/renderer/mcp-apps/McpAppPanel.tsx
@@ -308,6 +308,135 @@ export function McpAppPanel({ panel, onClose, isActive = true }: McpAppPanelProp
             );
           }
         }
+
+        // ============================================
+        // Server Config specific JSON-RPC methods
+        // ============================================
+
+        // Get server configurations with status
+        if (data.method === 'server-config/getServers' && data.id) {
+          try {
+            const servers = await adapter.getServerConfigs();
+            sendToApp(createJsonRpcResponse(data.id, { servers }));
+          } catch (error) {
+            console.error('[McpAppPanel] server-config/getServers error:', error);
+            sendToApp(
+              createJsonRpcError(data.id, -32603, 'Failed to get server configs')
+            );
+          }
+        }
+
+        // Add a new server
+        if (data.method === 'server-config/addServer' && data.id) {
+          try {
+            const { name, command, args, env } = data.params;
+            const result = await adapter.addServerConfig({ name, command, args, env });
+            sendToApp(createJsonRpcResponse(data.id, result));
+          } catch (error) {
+            console.error('[McpAppPanel] server-config/addServer error:', error);
+            sendToApp(
+              createJsonRpcError(data.id, -32603, error instanceof Error ? error.message : 'Failed to add server')
+            );
+          }
+        }
+
+        // Update server configuration
+        if (data.method === 'server-config/updateServer' && data.id) {
+          try {
+            const { name, command, args, env, enabled } = data.params;
+            const result = await adapter.updateServerConfig(name, { command, args, env, enabled });
+            sendToApp(createJsonRpcResponse(data.id, result));
+          } catch (error) {
+            console.error('[McpAppPanel] server-config/updateServer error:', error);
+            sendToApp(
+              createJsonRpcError(data.id, -32603, error instanceof Error ? error.message : 'Failed to update server')
+            );
+          }
+        }
+
+        // Remove server configuration
+        if (data.method === 'server-config/removeServer' && data.id) {
+          try {
+            const { name } = data.params;
+            const result = await adapter.removeServerConfig(name);
+            sendToApp(createJsonRpcResponse(data.id, result));
+          } catch (error) {
+            console.error('[McpAppPanel] server-config/removeServer error:', error);
+            sendToApp(
+              createJsonRpcError(data.id, -32603, error instanceof Error ? error.message : 'Failed to remove server')
+            );
+          }
+        }
+
+        // Set server enabled state (reuse from tool-manager pattern but for server-config)
+        if (data.method === 'server-config/setServerEnabled' && data.id) {
+          try {
+            const { name, enabled } = data.params;
+            const result = await adapter.updateServerConfig(name, { enabled });
+            sendToApp(createJsonRpcResponse(data.id, result));
+          } catch (error) {
+            console.error('[McpAppPanel] server-config/setServerEnabled error:', error);
+            sendToApp(
+              createJsonRpcError(data.id, -32603, 'Failed to update server enabled state')
+            );
+          }
+        }
+
+        // Restart server
+        if (data.method === 'server-config/restartServer' && data.id) {
+          try {
+            const { name } = data.params;
+            // Note: restartServer is exposed through window.electronAPI but not through the adapter yet
+            // For now, we'll use the direct electronAPI if available
+            if (window.electronAPI && 'restartServer' in window.electronAPI) {
+              await (window.electronAPI as { restartServer: (name: string) => Promise<void> }).restartServer(name);
+              sendToApp(createJsonRpcResponse(data.id, { success: true }));
+            } else {
+              sendToApp(createJsonRpcError(data.id, -32603, 'Restart not available'));
+            }
+          } catch (error) {
+            console.error('[McpAppPanel] server-config/restartServer error:', error);
+            sendToApp(
+              createJsonRpcError(data.id, -32603, 'Failed to restart server')
+            );
+          }
+        }
+
+        // Stop server
+        if (data.method === 'server-config/stopServer' && data.id) {
+          try {
+            const { name } = data.params;
+            if (window.electronAPI && 'stopServer' in window.electronAPI) {
+              await (window.electronAPI as { stopServer: (name: string) => Promise<void> }).stopServer(name);
+              sendToApp(createJsonRpcResponse(data.id, { success: true }));
+            } else {
+              sendToApp(createJsonRpcError(data.id, -32603, 'Stop not available'));
+            }
+          } catch (error) {
+            console.error('[McpAppPanel] server-config/stopServer error:', error);
+            sendToApp(
+              createJsonRpcError(data.id, -32603, 'Failed to stop server')
+            );
+          }
+        }
+
+        // Start server
+        if (data.method === 'server-config/startServer' && data.id) {
+          try {
+            const { name } = data.params;
+            if (window.electronAPI && 'startServer' in window.electronAPI) {
+              await (window.electronAPI as { startServer: (name: string) => Promise<void> }).startServer(name);
+              sendToApp(createJsonRpcResponse(data.id, { success: true }));
+            } else {
+              sendToApp(createJsonRpcError(data.id, -32603, 'Start not available'));
+            }
+          } catch (error) {
+            console.error('[McpAppPanel] server-config/startServer error:', error);
+            sendToApp(
+              createJsonRpcError(data.id, -32603, 'Failed to start server')
+            );
+          }
+        }
       }
     };
 

--- a/src/renderer/settings/types.ts
+++ b/src/renderer/settings/types.ts
@@ -62,7 +62,7 @@ export const defaultModelSettings: ModelSettings = {
     provider: 'anthropic',
     modelId: 'claude-haiku-4-5-20251001',
     temperature: 0.3, // Low for deterministic task execution
-    maxTurns: 1, // Single step - fast and focused
+    maxTurns: 5, // Multiple steps for multi-tool workflows
   },
   dreamer: {
     provider: 'anthropic',

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -128,6 +128,22 @@ export const ON_SERVER_RESTARTING = 'mcp:on-server-restarting';
 export const ON_MANAGER_READY = 'mcp:on-manager-ready';
 
 // ============================================
+// Server Configuration Channels
+// ============================================
+
+/** Get server configurations from servers.json */
+export const GET_SERVER_CONFIGS = 'config:get-servers';
+
+/** Add a new server to servers.json */
+export const ADD_SERVER_CONFIG = 'config:add-server';
+
+/** Update an existing server in servers.json */
+export const UPDATE_SERVER_CONFIG = 'config:update-server';
+
+/** Remove a server from servers.json */
+export const REMOVE_SERVER_CONFIG = 'config:remove-server';
+
+// ============================================
 // Settings Channels
 // ============================================
 
@@ -180,6 +196,11 @@ export const INVOKE_CHANNELS = [
   RESTART_SERVER,
   STOP_SERVER,
   START_SERVER,
+  // Server configuration
+  GET_SERVER_CONFIGS,
+  ADD_SERVER_CONFIG,
+  UPDATE_SERVER_CONFIG,
+  REMOVE_SERVER_CONFIG,
 ] as const;
 
 /** Channels that renderer can listen to (main → renderer events) */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -86,6 +86,8 @@ export interface ToolWithUIInfo {
   /** Original tool name for display */
   displayName: string;
   description?: string;
+  /** JSON Schema for tool parameters */
+  inputSchema?: Record<string, unknown>;
   hasUi: boolean;
   uiResourceUri?: string;
   serverName: string;
@@ -242,6 +244,42 @@ export interface WebConfig {
   sandboxPort: number;
   multiServer: boolean;
   serverCount: number;
+}
+
+// ============================================
+// Server Configuration Types (for Server Config UI)
+// ============================================
+
+/**
+ * Server configuration entry as stored in servers.json
+ */
+export interface ServerConfigEntry {
+  /** Server name (unique identifier) */
+  name: string;
+  /** Transport type */
+  transport: 'stdio';
+  /** Command to execute */
+  command: string;
+  /** Command arguments */
+  args?: string[];
+  /** Environment variables */
+  env?: Record<string, string>;
+  /** Whether the server is enabled */
+  enabled?: boolean;
+}
+
+/**
+ * Server configuration with runtime status
+ */
+export interface ServerConfigWithStatus extends ServerConfigEntry {
+  /** Runtime connection status */
+  status: import('@skilljack/mcp-server-manager').ServerStatus;
+  /** Number of tools provided by this server */
+  toolCount: number;
+  /** Whether the server is healthy */
+  healthy: boolean;
+  /** Last error message if any */
+  lastError?: string;
 }
 
 // ============================================

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -162,13 +162,49 @@ export interface ChatRequest {
   settings: ChatSettings;
 }
 
-export interface ChatApiMessage {
-  role: 'user' | 'assistant' | 'system';
+/**
+ * Message format for the chat API.
+ * Supports text messages and tool call/result messages matching AI SDK format.
+ */
+export type ChatApiMessage =
+  | ChatApiUserMessage
+  | ChatApiAssistantMessage
+  | ChatApiToolMessage
+  | ChatApiSystemMessage;
+
+export interface ChatApiUserMessage {
+  role: 'user';
   content: string;
-  toolCalls?: ToolCallInfo[];
-  toolResults?: ToolResultInfo[];
 }
 
+export interface ChatApiSystemMessage {
+  role: 'system';
+  content: string;
+}
+
+export interface ChatApiAssistantMessage {
+  role: 'assistant';
+  content: string | ChatApiAssistantContentPart[];
+}
+
+export type ChatApiAssistantContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'tool-call'; toolCallId: string; toolName: string; args: Record<string, unknown> };
+
+export interface ChatApiToolMessage {
+  role: 'tool';
+  content: ChatApiToolResultPart[];
+}
+
+export interface ChatApiToolResultPart {
+  type: 'tool-result';
+  toolCallId: string;
+  toolName: string;
+  result: unknown;
+  isError?: boolean;
+}
+
+// Legacy types for backwards compatibility
 export interface ToolCallInfo {
   id: string;
   name: string;

--- a/src/web/static/server-config/mcp-app.html
+++ b/src/web/static/server-config/mcp-app.html
@@ -809,7 +809,8 @@
     }
 
     function toggleExpand(name) {
-      const card = document.getElementById(`card-${name}`);
+      // Use escapeHtml to match the ID format used in renderServers
+      const card = document.getElementById(`card-${escapeHtml(name)}`);
       if (card) {
         card.classList.toggle('expanded');
       }

--- a/src/web/static/server-config/mcp-app.html
+++ b/src/web/static/server-config/mcp-app.html
@@ -1,0 +1,936 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <title>Server Configuration</title>
+  <style>
+    :root {
+      --bg: #1a1a2e;
+      --bg-secondary: #16213e;
+      --bg-tertiary: #0f1729;
+      --text: #e8e8e8;
+      --text-secondary: #a0a0a0;
+      --accent: #6366f1;
+      --accent-hover: #818cf8;
+      --border: #2a2a4a;
+      --success: #22c55e;
+      --warning: #eab308;
+      --error: #ef4444;
+      --info: #3b82f6;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #ffffff;
+        --bg-secondary: #f5f5f5;
+        --bg-tertiary: #e8e8e8;
+        --text: #1a1a1a;
+        --text-secondary: #666666;
+        --border: #e0e0e0;
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      padding: 12px;
+      min-height: 100vh;
+      overflow-y: auto;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 16px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    h1 {
+      font-size: 18px;
+      font-weight: 600;
+    }
+
+    .stats {
+      font-size: 12px;
+      color: var(--text-secondary);
+    }
+
+    .add-btn {
+      padding: 6px 12px;
+      background: var(--accent);
+      color: white;
+      border: none;
+      border-radius: 6px;
+      font-size: 13px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .add-btn:hover {
+      background: var(--accent-hover);
+    }
+
+    /* Server card */
+    .server-card {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      margin-bottom: 8px;
+      overflow: hidden;
+    }
+
+    .server-card.disabled {
+      opacity: 0.6;
+    }
+
+    .server-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 12px;
+      gap: 12px;
+    }
+
+    .server-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .server-name-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 4px;
+    }
+
+    .server-name {
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .status-badge {
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 4px;
+      text-transform: capitalize;
+    }
+
+    .status-badge.connected { background: var(--success); color: white; }
+    .status-badge.connecting { background: var(--info); color: white; }
+    .status-badge.disconnected { background: var(--text-secondary); color: white; }
+    .status-badge.unhealthy { background: var(--warning); color: black; }
+    .status-badge.restarting { background: var(--info); color: white; }
+    .status-badge.failed { background: var(--error); color: white; }
+    .status-badge.stopped { background: var(--text-secondary); color: white; }
+
+    .server-command {
+      font-size: 11px;
+      color: var(--text-secondary);
+      font-family: 'Fira Code', monospace;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .server-actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .action-btn {
+      padding: 4px 8px;
+      background: var(--bg-tertiary);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-size: 11px;
+      cursor: pointer;
+    }
+
+    .action-btn:hover {
+      background: var(--border);
+    }
+
+    .action-btn.danger {
+      color: var(--error);
+    }
+
+    .action-btn.danger:hover {
+      background: var(--error);
+      color: white;
+      border-color: var(--error);
+    }
+
+    .toggle {
+      position: relative;
+      width: 36px;
+      height: 20px;
+      flex-shrink: 0;
+    }
+
+    .toggle input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .toggle-slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: var(--border);
+      transition: 0.3s;
+      border-radius: 24px;
+    }
+
+    .toggle-slider:before {
+      position: absolute;
+      content: "";
+      height: 14px;
+      width: 14px;
+      left: 3px;
+      bottom: 3px;
+      background-color: white;
+      transition: 0.3s;
+      border-radius: 50%;
+    }
+
+    .toggle input:checked + .toggle-slider {
+      background-color: var(--success);
+    }
+
+    .toggle input:checked + .toggle-slider:before {
+      transform: translateX(16px);
+    }
+
+    /* Server details (collapsible) */
+    .server-details {
+      display: none;
+      padding: 10px 12px;
+      border-top: 1px solid var(--border);
+      background: var(--bg-tertiary);
+    }
+
+    .server-card.expanded .server-details {
+      display: block;
+    }
+
+    .detail-row {
+      display: flex;
+      margin-bottom: 8px;
+    }
+
+    .detail-label {
+      width: 80px;
+      font-size: 11px;
+      color: var(--text-secondary);
+      flex-shrink: 0;
+    }
+
+    .detail-value {
+      font-size: 11px;
+      font-family: 'Fira Code', monospace;
+      word-break: break-all;
+    }
+
+    .env-list {
+      font-size: 11px;
+      font-family: 'Fira Code', monospace;
+    }
+
+    .env-item {
+      margin-bottom: 2px;
+    }
+
+    .expand-btn {
+      font-size: 10px;
+      color: var(--text-secondary);
+      cursor: pointer;
+      padding: 4px;
+    }
+
+    /* Modal / Form */
+    .modal-overlay {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.6);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .modal-overlay.active {
+      display: flex;
+    }
+
+    .modal {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      width: 90%;
+      max-width: 400px;
+      max-height: 90vh;
+      overflow-y: auto;
+    }
+
+    .modal-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .modal-header h2 {
+      font-size: 16px;
+      font-weight: 600;
+    }
+
+    .modal-close {
+      background: none;
+      border: none;
+      font-size: 20px;
+      color: var(--text-secondary);
+      cursor: pointer;
+    }
+
+    .modal-body {
+      padding: 16px;
+    }
+
+    .form-group {
+      margin-bottom: 12px;
+    }
+
+    .form-group label {
+      display: block;
+      font-size: 12px;
+      margin-bottom: 4px;
+      color: var(--text-secondary);
+    }
+
+    .form-group input,
+    .form-group textarea {
+      width: 100%;
+      padding: 8px 10px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 13px;
+      font-family: 'Fira Code', monospace;
+    }
+
+    .form-group input:focus,
+    .form-group textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+    }
+
+    .form-hint {
+      font-size: 10px;
+      color: var(--text-secondary);
+      margin-top: 4px;
+    }
+
+    .modal-footer {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      padding: 12px 16px;
+      border-top: 1px solid var(--border);
+    }
+
+    .btn {
+      padding: 8px 16px;
+      border-radius: 6px;
+      font-size: 13px;
+      cursor: pointer;
+      border: none;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: white;
+    }
+
+    .btn-primary:hover {
+      background: var(--accent-hover);
+    }
+
+    .btn-secondary {
+      background: var(--bg);
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+
+    .btn-secondary:hover {
+      background: var(--border);
+    }
+
+    .loading {
+      text-align: center;
+      padding: 40px;
+      color: var(--text-secondary);
+    }
+
+    .error {
+      text-align: center;
+      padding: 40px;
+      color: var(--error);
+    }
+
+    .empty {
+      text-align: center;
+      padding: 40px;
+      color: var(--text-secondary);
+    }
+
+    .toast {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      padding: 12px 16px;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-size: 13px;
+      z-index: 200;
+      display: none;
+    }
+
+    .toast.success {
+      border-color: var(--success);
+      color: var(--success);
+    }
+
+    .toast.error {
+      border-color: var(--error);
+      color: var(--error);
+    }
+
+    .toast.visible {
+      display: block;
+      animation: slideIn 0.3s ease;
+    }
+
+    @keyframes slideIn {
+      from {
+        transform: translateX(100%);
+        opacity: 0;
+      }
+      to {
+        transform: translateX(0);
+        opacity: 1;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div>
+      <h1>Server Configuration</h1>
+      <div class="stats" id="stats">Loading...</div>
+    </div>
+    <button class="add-btn" onclick="showAddForm()">
+      <span>+</span> Add Server
+    </button>
+  </div>
+
+  <div id="server-list">
+    <div class="loading">Loading servers...</div>
+  </div>
+
+  <!-- Add/Edit Server Modal -->
+  <div class="modal-overlay" id="modal">
+    <div class="modal">
+      <div class="modal-header">
+        <h2 id="modal-title">Add Server</h2>
+        <button class="modal-close" onclick="closeModal()">&times;</button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label for="server-name">Server Name *</label>
+          <input type="text" id="server-name" placeholder="my-server">
+          <div class="form-hint">Unique identifier for this server</div>
+        </div>
+        <div class="form-group">
+          <label for="server-command">Command *</label>
+          <input type="text" id="server-command" placeholder="npx">
+          <div class="form-hint">Command to execute (e.g., npx, node, python)</div>
+        </div>
+        <div class="form-group">
+          <label for="server-args">Arguments</label>
+          <input type="text" id="server-args" placeholder="-y @modelcontextprotocol/server-everything">
+          <div class="form-hint">Space-separated arguments</div>
+        </div>
+        <div class="form-group">
+          <label for="server-env">Environment Variables</label>
+          <textarea id="server-env" rows="3" placeholder="KEY=value&#10;ANOTHER_KEY=value"></textarea>
+          <div class="form-hint">One per line: KEY=value</div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+        <button class="btn btn-primary" id="modal-submit" onclick="submitForm()">Add Server</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast notification -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // State
+    let servers = [];
+    let editingServer = null;
+    let useJsonRpc = false;
+    let rpcRequestId = 1;
+    const pendingRequests = new Map();
+
+    // Get host origin
+    const hostOrigin = window.__HOST_ORIGIN__
+      || (document.referrer ? new URL(document.referrer).origin : window.location.origin);
+
+    // Detect if we're in an iframe
+    const isInIframe = window.parent !== window;
+
+    // Elements
+    const serverList = document.getElementById('server-list');
+    const stats = document.getElementById('stats');
+    const modal = document.getElementById('modal');
+    const toast = document.getElementById('toast');
+
+    // ============================================
+    // JSON-RPC Communication
+    // ============================================
+
+    function sendRpcRequest(method, params = {}) {
+      return new Promise((resolve, reject) => {
+        const id = rpcRequestId++;
+        pendingRequests.set(id, { resolve, reject });
+
+        window.parent.postMessage({
+          jsonrpc: '2.0',
+          id,
+          method,
+          params
+        }, '*');
+
+        setTimeout(() => {
+          if (pendingRequests.has(id)) {
+            pendingRequests.delete(id);
+            reject(new Error('Request timeout'));
+          }
+        }, 10000);
+      });
+    }
+
+    window.addEventListener('message', (event) => {
+      const data = event.data;
+      if (!data || typeof data !== 'object' || data.jsonrpc !== '2.0') return;
+
+      if (data.id && pendingRequests.has(data.id)) {
+        const { resolve, reject } = pendingRequests.get(data.id);
+        pendingRequests.delete(data.id);
+
+        if (data.error) {
+          reject(new Error(data.error.message || 'RPC error'));
+        } else {
+          resolve(data.result);
+        }
+      }
+    });
+
+    // ============================================
+    // Data Operations
+    // ============================================
+
+    async function fetchServers() {
+      try {
+        let data;
+        if (useJsonRpc) {
+          data = await sendRpcRequest('server-config/getServers');
+        } else {
+          const res = await fetch(`${hostOrigin}/api/server-config/servers`);
+          if (!res.ok) throw new Error('Failed to fetch servers');
+          data = await res.json();
+        }
+        servers = data.servers || [];
+        renderServers();
+        updateStats();
+      } catch (err) {
+        if (!useJsonRpc && isInIframe) {
+          console.log('[ServerConfig] HTTP failed, switching to JSON-RPC mode');
+          useJsonRpc = true;
+          return fetchServers();
+        }
+        serverList.innerHTML = `<div class="error">Failed to load servers: ${err.message}</div>`;
+      }
+    }
+
+    async function addServer(config) {
+      try {
+        if (useJsonRpc) {
+          await sendRpcRequest('server-config/addServer', config);
+        } else {
+          const res = await fetch(`${hostOrigin}/api/server-config/servers`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(config),
+          });
+          if (!res.ok) throw new Error('Failed to add server');
+        }
+        showToast('Server added successfully', 'success');
+        await fetchServers();
+      } catch (err) {
+        showToast(err.message, 'error');
+        throw err;
+      }
+    }
+
+    async function updateServer(name, config) {
+      try {
+        if (useJsonRpc) {
+          await sendRpcRequest('server-config/updateServer', { name, ...config });
+        } else {
+          const res = await fetch(`${hostOrigin}/api/server-config/servers/${encodeURIComponent(name)}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(config),
+          });
+          if (!res.ok) throw new Error('Failed to update server');
+        }
+        showToast('Server updated successfully', 'success');
+        await fetchServers();
+      } catch (err) {
+        showToast(err.message, 'error');
+        throw err;
+      }
+    }
+
+    async function removeServer(name) {
+      if (!confirm(`Are you sure you want to remove "${name}"?`)) return;
+
+      try {
+        if (useJsonRpc) {
+          await sendRpcRequest('server-config/removeServer', { name });
+        } else {
+          const res = await fetch(`${hostOrigin}/api/server-config/servers/${encodeURIComponent(name)}`, {
+            method: 'DELETE',
+          });
+          if (!res.ok) throw new Error('Failed to remove server');
+        }
+        showToast('Server removed successfully', 'success');
+        await fetchServers();
+      } catch (err) {
+        showToast(err.message, 'error');
+      }
+    }
+
+    async function toggleServerEnabled(name, enabled) {
+      try {
+        if (useJsonRpc) {
+          await sendRpcRequest('server-config/setServerEnabled', { name, enabled });
+        } else {
+          await updateServer(name, { enabled });
+          return;
+        }
+        showToast(`Server ${enabled ? 'enabled' : 'disabled'}`, 'success');
+        await fetchServers();
+      } catch (err) {
+        showToast(err.message, 'error');
+        renderServers(); // Revert UI
+      }
+    }
+
+    async function restartServer(name) {
+      try {
+        if (useJsonRpc) {
+          await sendRpcRequest('server-config/restartServer', { name });
+        } else {
+          const res = await fetch(`${hostOrigin}/api/server-config/servers/${encodeURIComponent(name)}/restart`, {
+            method: 'POST',
+          });
+          if (!res.ok) throw new Error('Failed to restart server');
+        }
+        showToast('Server restarting...', 'success');
+        await fetchServers();
+      } catch (err) {
+        showToast(err.message, 'error');
+      }
+    }
+
+    async function stopServer(name) {
+      try {
+        if (useJsonRpc) {
+          await sendRpcRequest('server-config/stopServer', { name });
+        } else {
+          const res = await fetch(`${hostOrigin}/api/server-config/servers/${encodeURIComponent(name)}/stop`, {
+            method: 'POST',
+          });
+          if (!res.ok) throw new Error('Failed to stop server');
+        }
+        showToast('Server stopped', 'success');
+        await fetchServers();
+      } catch (err) {
+        showToast(err.message, 'error');
+      }
+    }
+
+    async function startServer(name) {
+      try {
+        if (useJsonRpc) {
+          await sendRpcRequest('server-config/startServer', { name });
+        } else {
+          const res = await fetch(`${hostOrigin}/api/server-config/servers/${encodeURIComponent(name)}/start`, {
+            method: 'POST',
+          });
+          if (!res.ok) throw new Error('Failed to start server');
+        }
+        showToast('Server starting...', 'success');
+        await fetchServers();
+      } catch (err) {
+        showToast(err.message, 'error');
+      }
+    }
+
+    // ============================================
+    // UI Rendering
+    // ============================================
+
+    function updateStats() {
+      const connected = servers.filter(s => s.status === 'connected').length;
+      const enabled = servers.filter(s => s.enabled !== false).length;
+      stats.textContent = `${connected}/${servers.length} connected, ${enabled}/${servers.length} enabled`;
+    }
+
+    function renderServers() {
+      if (servers.length === 0) {
+        serverList.innerHTML = `
+          <div class="empty">
+            No servers configured.<br>
+            Click "Add Server" to get started.
+          </div>
+        `;
+        return;
+      }
+
+      serverList.innerHTML = servers.map(server => {
+        const commandLine = server.args?.length
+          ? `${server.command} ${server.args.join(' ')}`
+          : server.command;
+
+        const envEntries = server.env ? Object.entries(server.env) : [];
+
+        return `
+          <div class="server-card ${server.enabled === false ? 'disabled' : ''}" id="card-${escapeHtml(server.name)}">
+            <div class="server-header">
+              <div class="server-info">
+                <div class="server-name-row">
+                  <span class="server-name">${escapeHtml(server.name)}</span>
+                  <span class="status-badge ${server.status}">${server.status}</span>
+                  <span class="expand-btn" onclick="toggleExpand('${escapeJs(server.name)}')">▼</span>
+                </div>
+                <div class="server-command">${escapeHtml(commandLine)}</div>
+              </div>
+              <div class="server-actions">
+                ${server.status === 'stopped' || server.status === 'failed'
+                  ? `<button class="action-btn" onclick="startServer('${escapeJs(server.name)}')">Start</button>`
+                  : server.status === 'connected' || server.status === 'unhealthy'
+                    ? `<button class="action-btn" onclick="restartServer('${escapeJs(server.name)}')">Restart</button>
+                       <button class="action-btn" onclick="stopServer('${escapeJs(server.name)}')">Stop</button>`
+                    : ''
+                }
+                <button class="action-btn" onclick="showEditForm('${escapeJs(server.name)}')">Edit</button>
+                <button class="action-btn danger" onclick="removeServer('${escapeJs(server.name)}')">Remove</button>
+                <label class="toggle">
+                  <input type="checkbox"
+                         ${server.enabled !== false ? 'checked' : ''}
+                         onchange="toggleServerEnabled('${escapeJs(server.name)}', this.checked)">
+                  <span class="toggle-slider"></span>
+                </label>
+              </div>
+            </div>
+            <div class="server-details">
+              <div class="detail-row">
+                <span class="detail-label">Command:</span>
+                <span class="detail-value">${escapeHtml(server.command)}</span>
+              </div>
+              ${server.args?.length ? `
+                <div class="detail-row">
+                  <span class="detail-label">Arguments:</span>
+                  <span class="detail-value">${escapeHtml(server.args.join(' '))}</span>
+                </div>
+              ` : ''}
+              <div class="detail-row">
+                <span class="detail-label">Tools:</span>
+                <span class="detail-value">${server.toolCount || 0} tools</span>
+              </div>
+              ${server.lastError ? `
+                <div class="detail-row">
+                  <span class="detail-label">Error:</span>
+                  <span class="detail-value" style="color: var(--error);">${escapeHtml(server.lastError)}</span>
+                </div>
+              ` : ''}
+              ${envEntries.length ? `
+                <div class="detail-row">
+                  <span class="detail-label">Env:</span>
+                  <div class="env-list">
+                    ${envEntries.map(([k, v]) => `<div class="env-item">${escapeHtml(k)}=${escapeHtml(v)}</div>`).join('')}
+                  </div>
+                </div>
+              ` : ''}
+            </div>
+          </div>
+        `;
+      }).join('');
+    }
+
+    function toggleExpand(name) {
+      const card = document.getElementById(`card-${name}`);
+      if (card) {
+        card.classList.toggle('expanded');
+      }
+    }
+
+    // ============================================
+    // Modal / Form
+    // ============================================
+
+    function showAddForm() {
+      editingServer = null;
+      document.getElementById('modal-title').textContent = 'Add Server';
+      document.getElementById('modal-submit').textContent = 'Add Server';
+      document.getElementById('server-name').value = '';
+      document.getElementById('server-name').disabled = false;
+      document.getElementById('server-command').value = '';
+      document.getElementById('server-args').value = '';
+      document.getElementById('server-env').value = '';
+      modal.classList.add('active');
+    }
+
+    function showEditForm(name) {
+      const server = servers.find(s => s.name === name);
+      if (!server) return;
+
+      editingServer = name;
+      document.getElementById('modal-title').textContent = 'Edit Server';
+      document.getElementById('modal-submit').textContent = 'Save Changes';
+      document.getElementById('server-name').value = server.name;
+      document.getElementById('server-name').disabled = true;
+      document.getElementById('server-command').value = server.command || '';
+      document.getElementById('server-args').value = (server.args || []).join(' ');
+      document.getElementById('server-env').value = server.env
+        ? Object.entries(server.env).map(([k, v]) => `${k}=${v}`).join('\n')
+        : '';
+      modal.classList.add('active');
+    }
+
+    function closeModal() {
+      modal.classList.remove('active');
+      editingServer = null;
+    }
+
+    async function submitForm() {
+      const name = document.getElementById('server-name').value.trim();
+      const command = document.getElementById('server-command').value.trim();
+      const argsStr = document.getElementById('server-args').value.trim();
+      const envStr = document.getElementById('server-env').value.trim();
+
+      if (!name || !command) {
+        showToast('Name and command are required', 'error');
+        return;
+      }
+
+      // Parse args
+      const args = argsStr ? argsStr.split(/\s+/).filter(Boolean) : [];
+
+      // Parse env
+      const env = {};
+      if (envStr) {
+        for (const line of envStr.split('\n')) {
+          const [key, ...rest] = line.split('=');
+          if (key && rest.length) {
+            env[key.trim()] = rest.join('=').trim();
+          }
+        }
+      }
+
+      try {
+        if (editingServer) {
+          await updateServer(editingServer, { command, args, env: Object.keys(env).length ? env : undefined });
+        } else {
+          await addServer({ name, command, args, env: Object.keys(env).length ? env : undefined });
+        }
+        closeModal();
+      } catch (err) {
+        // Error already shown via toast
+      }
+    }
+
+    // ============================================
+    // Toast
+    // ============================================
+
+    function showToast(message, type = 'success') {
+      toast.textContent = message;
+      toast.className = `toast ${type} visible`;
+      setTimeout(() => {
+        toast.classList.remove('visible');
+      }, 3000);
+    }
+
+    // ============================================
+    // Utilities
+    // ============================================
+
+    function escapeHtml(str) {
+      if (!str) return '';
+      return String(str).replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+      })[c]);
+    }
+
+    function escapeJs(str) {
+      if (!str) return '';
+      return String(str).replace(/[\\'"]/g, '\\$&');
+    }
+
+    // ============================================
+    // Initialize
+    // ============================================
+
+    if (isInIframe) {
+      console.log('[ServerConfig] Running in iframe, using JSON-RPC mode');
+      useJsonRpc = true;
+    }
+
+    fetchServers();
+
+    // Auto-refresh every 5 seconds
+    setInterval(fetchServers, 5000);
+  </script>
+</body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "jsx": "react-jsx"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/web/chat"]
+  "exclude": ["node_modules", "dist", "src/web/chat", "src/renderer"]
 }


### PR DESCRIPTION
## Summary

- **Server Config MCP App**: New UI panel for viewing and managing server configurations with real-time status updates
- **Multi-turn tool workflows**: Assistant can now chain multiple tool calls automatically (e.g., "enable everything server" → list servers → enable server → confirm)
- **Enable/disable server tools**: New tools to toggle server availability without stopping the process
- **Bug fixes**: Various fixes for tool execution, conversation history, and server lifecycle

## Key Changes

### Multi-Turn Tool Workflows
- Added auto-continue mechanism that triggers after tool execution completes
- Tracks turn count to respect `maxTurns` limit (Doer: 5, Dreamer: 10)
- Properly formats tool calls and results for Anthropic API
- Prevents duplicate continuation triggers with ref tracking

### Server Config Tools
- `list-servers` - List all server configs with status
- `add-server` / `remove-server` - Manage server configs
- `start-server` / `stop-server` / `restart-server` - Control server processes
- `enable-server` / `disable-server` - Toggle server tool availability

### Bug Fixes
- Fixed tool_use/tool_result mismatch error (only include completed tools in history)
- Fixed servers not starting from 'stopped' state
- Pass inputSchema through to system prompt so LLM knows required parameters
- Auto-focus chat input on app start and after responses

## Test Plan

- [ ] Send "list servers" - should show all configured servers
- [ ] Send "enable everything server" - should chain: list → enable → confirm
- [ ] Stop a server, then start it again - should work from 'stopped' state
- [ ] Verify UI updates when server state changes through chat
- [ ] Verify max turns limit is respected (shouldn't loop forever)

🦉 Generated with [Claude Code](https://claude.com/claude-code)