### PR TITLE
fix: resolve nested button HTML error in tab view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# Skilljack Client
+
+## Setup
+
+After cloning or switching branches, build the local mcp-server-manager package before running the dev server:
+
+```bash
+cd packages/mcp-server-manager && npm run build
+```
+
+Then start the Electron app:
+
+```bash
+npm run electron:dev
+```
+
+## Project Structure
+
+- `packages/mcp-server-manager` - Local package for MCP server management
+- `src/electron` - Electron main process and preload scripts
+- `src/renderer` - React frontend

--- a/src/renderer/mcp-apps/McpAppContext.tsx
+++ b/src/renderer/mcp-apps/McpAppContext.tsx
@@ -152,8 +152,14 @@ function reducer(state: McpAppState, action: McpAppAction): McpAppState {
       };
     }
 
-    case 'SET_LAYOUT_MODE':
-      return { ...state, layoutMode: action.mode };
+    case 'SET_LAYOUT_MODE': {
+      // When switching to tabs mode, ensure activeTabKey is set
+      let newActiveTabKey = state.activeTabKey;
+      if (action.mode === 'tabs' && !state.activeTabKey && state.panels.size > 0) {
+        newActiveTabKey = Array.from(state.panels.keys())[0];
+      }
+      return { ...state, layoutMode: action.mode, activeTabKey: newActiveTabKey };
+    }
 
     case 'SET_ACTIVE_TAB':
       return { ...state, activeTabKey: action.key };

--- a/src/renderer/mcp-apps/McpAppPanelsContainer.tsx
+++ b/src/renderer/mcp-apps/McpAppPanelsContainer.tsx
@@ -87,15 +87,24 @@ export function McpAppPanelsContainer() {
 
       {/* Tab Bar (only shown in tabs mode) */}
       {layoutMode === 'tabs' && (
-        <div className="mcp-app-tabs">
+        <div className="mcp-app-tabs" role="tablist">
           {panels.map((panel) => {
             const toolName =
               panel.uiResourceUri.split('/').pop() || panel.uiResourceUri;
             return (
-              <button
+              <div
                 key={panel.key}
                 className={`mcp-app-tab ${activeTabKey === panel.key ? 'active' : ''}`}
                 onClick={() => setActiveTab(panel.key)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setActiveTab(panel.key);
+                  }
+                }}
+                role="tab"
+                tabIndex={0}
+                aria-selected={activeTabKey === panel.key}
               >
                 <span className="mcp-tab-label">
                   {toolName} ({panel.serverName})
@@ -110,7 +119,7 @@ export function McpAppPanelsContainer() {
                 >
                   &times;
                 </button>
-              </button>
+              </div>
             );
           })}
         </div>

--- a/src/web/static/server-config/mcp-app.html
+++ b/src/web/static/server-config/mcp-app.html
@@ -498,6 +498,23 @@
     </div>
   </div>
 
+  <!-- Confirm Modal -->
+  <div class="modal-overlay" id="confirm-modal">
+    <div class="modal" style="max-width: 400px;">
+      <div class="modal-header">
+        <h2>Confirm</h2>
+        <button class="modal-close" onclick="closeConfirmModal(false)">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p id="confirm-message"></p>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" onclick="closeConfirmModal(false)">Cancel</button>
+        <button class="btn btn-primary" id="confirm-yes" onclick="closeConfirmModal(true)">Yes, Remove</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Toast notification -->
   <div class="toast" id="toast"></div>
 
@@ -520,7 +537,11 @@
     const serverList = document.getElementById('server-list');
     const stats = document.getElementById('stats');
     const modal = document.getElementById('modal');
+    const confirmModal = document.getElementById('confirm-modal');
     const toast = document.getElementById('toast');
+
+    // Confirm modal state
+    let confirmCallback = null;
 
     // ============================================
     // JSON-RPC Communication
@@ -631,7 +652,8 @@
     }
 
     async function removeServer(name) {
-      if (!confirm(`Are you sure you want to remove "${name}"?`)) return;
+      const confirmed = await showConfirmModal(`Are you sure you want to remove "${name}"?`);
+      if (!confirmed) return;
 
       try {
         if (useJsonRpc) {
@@ -852,6 +874,22 @@
     function closeModal() {
       modal.classList.remove('active');
       editingServer = null;
+    }
+
+    function showConfirmModal(message) {
+      return new Promise((resolve) => {
+        document.getElementById('confirm-message').textContent = message;
+        confirmCallback = resolve;
+        confirmModal.classList.add('active');
+      });
+    }
+
+    function closeConfirmModal(result) {
+      confirmModal.classList.remove('active');
+      if (confirmCallback) {
+        confirmCallback(result);
+        confirmCallback = null;
+      }
     }
 
     async function submitForm() {


### PR DESCRIPTION
## Summary
- Fixed invalid HTML where `<button>` (close) was nested inside `<button>` (tab), which caused hydration errors
- Changed tab element to `<div>` with proper ARIA attributes (`role="tab"`, `tabIndex`, `aria-selected`)
- Added keyboard support (Enter/Space) to maintain accessibility
- Replaced `confirm()` with custom modal in server config (blocked in sandboxed iframes)
- Auto-select first tab when switching to tabs layout mode
- Added `CLAUDE.md` with setup instructions for building local packages

## Test plan
- [ ] Open the app and switch to tabs layout mode
- [ ] Verify no console errors about nested buttons
- [ ] Verify first tab is automatically selected and content is visible
- [ ] Verify tabs are still clickable and keyboard accessible
- [ ] Verify close button still works
- [ ] Open server config and verify remove button shows custom confirm modal

Fixes #11, #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)