### PR TITLE
feat: add MCPB bundle installation support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "electron-log": "^5.4.3",
         "electron-squirrel-startup": "^1.0.1",
         "electron-store": "^11.0.2",
+        "fflate": "^0.8.2",
+        "node-forge": "^1.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "ws": "^8.19.0"
@@ -43,6 +45,7 @@
         "@electron-forge/plugin-vite": "^7.11.1",
         "@electron/fuses": "^1.8.0",
         "@types/node": "^22.0.0",
+        "@types/node-forge": "^1.3.14",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/ws": "^8.18.1",
@@ -3886,6 +3889,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
@@ -7020,6 +7033,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -8998,6 +9017,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "electron-log": "^5.4.3",
     "electron-squirrel-startup": "^1.0.1",
     "electron-store": "^11.0.2",
+    "fflate": "^0.8.2",
+    "node-forge": "^1.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "ws": "^8.19.0"
@@ -66,6 +68,7 @@
     "@electron-forge/plugin-vite": "^7.11.1",
     "@electron/fuses": "^1.8.0",
     "@types/node": "^22.0.0",
+    "@types/node-forge": "^1.3.14",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/ws": "^8.18.1",

--- a/src/electron/main/mcpb/index.ts
+++ b/src/electron/main/mcpb/index.ts
@@ -1,0 +1,282 @@
+/**
+ * MCPB (MCP Bundle) Installer
+ *
+ * Main entry point for MCPB installation functionality.
+ * Provides preview and install capabilities for MCPB bundles.
+ */
+
+import { app } from 'electron';
+import { existsSync, mkdirSync, rmSync } from 'fs';
+import { basename, join } from 'path';
+import log from 'electron-log';
+
+import { verifySignature } from './signature.js';
+import { unpackMcpb, readManifestFromMcpb } from './unpacker.js';
+import {
+  parseManifest,
+  checkPlatformCompatibility,
+  getMissingRequiredConfig,
+} from './manifest-parser.js';
+import { resolveServerConfig, resolveDefaultValue } from './variable-resolver.js';
+import type {
+  McpbPreviewResult,
+  McpbInstallOptions,
+  McpbInstallResult,
+  McpbManifest,
+} from './types.js';
+
+// Re-export types and functions for convenience
+export * from './types.js';
+export { resolveDefaultValue } from './variable-resolver.js';
+
+/**
+ * Get the extensions installation directory
+ */
+export function getExtensionsDir(): string {
+  return join(app.getPath('userData'), 'extensions');
+}
+
+/**
+ * Preview an MCPB file without installing
+ *
+ * Reads the manifest and verifies the signature without extracting.
+ * Use this to show confirmation UI before installation.
+ *
+ * @param mcpbPath Path to the .mcpb file
+ * @returns Preview result with manifest, signature info, and validation status
+ */
+export async function previewMcpb(mcpbPath: string): Promise<McpbPreviewResult> {
+  log.info('[MCPB] Previewing:', mcpbPath);
+
+  // Verify file exists
+  if (!existsSync(mcpbPath)) {
+    throw new Error(`MCPB file not found: ${mcpbPath}`);
+  }
+
+  // Read manifest without extracting
+  const manifestJson = readManifestFromMcpb(mcpbPath);
+  if (!manifestJson) {
+    throw new Error('manifest.json not found in MCPB file');
+  }
+
+  // Parse and validate manifest
+  const parseResult = parseManifest(manifestJson);
+  if (!parseResult.success || !parseResult.manifest) {
+    throw new Error(parseResult.error || 'Invalid manifest');
+  }
+
+  const manifest = parseResult.manifest;
+
+  // Verify signature
+  const signature = await verifySignature(mcpbPath);
+  log.info('[MCPB] Signature status:', signature.status);
+
+  // Check platform compatibility
+  const platformCompatible = checkPlatformCompatibility(manifest);
+
+  // Get missing required config (without user config provided yet)
+  const missingRequiredConfig = getMissingRequiredConfig(manifest);
+
+  return {
+    mcpbPath,
+    manifest,
+    signature,
+    platformCompatible,
+    missingRequiredConfig,
+  };
+}
+
+/**
+ * Install an MCPB file
+ *
+ * Extracts the bundle, validates the manifest, resolves variables,
+ * and returns the configuration ready for server registration.
+ *
+ * @param options Installation options
+ * @returns Installation result with resolved server configuration
+ */
+export async function installMcpb(options: McpbInstallOptions): Promise<McpbInstallResult> {
+  const { mcpbPath, userConfig, serverName: overrideName } = options;
+
+  log.info('[MCPB] Installing:', mcpbPath);
+
+  // Verify file exists
+  if (!existsSync(mcpbPath)) {
+    return {
+      success: false,
+      serverName: '',
+      message: `MCPB file not found: ${mcpbPath}`,
+    };
+  }
+
+  // Read manifest without extracting first to validate
+  const manifestJson = readManifestFromMcpb(mcpbPath);
+  if (!manifestJson) {
+    return {
+      success: false,
+      serverName: '',
+      message: 'manifest.json not found in MCPB file',
+    };
+  }
+
+  // Parse and validate manifest
+  const parseResult = parseManifest(manifestJson);
+  if (!parseResult.success || !parseResult.manifest) {
+    return {
+      success: false,
+      serverName: '',
+      message: parseResult.error || 'Invalid manifest',
+    };
+  }
+
+  const manifest = parseResult.manifest;
+  const finalServerName = overrideName || manifest.name;
+
+  // Check platform compatibility
+  if (!checkPlatformCompatibility(manifest)) {
+    return {
+      success: false,
+      serverName: finalServerName,
+      message: `Extension is not compatible with platform: ${process.platform}`,
+    };
+  }
+
+  // Check for missing required config
+  const missingConfig = getMissingRequiredConfig(manifest, userConfig);
+  if (missingConfig.length > 0) {
+    return {
+      success: false,
+      serverName: finalServerName,
+      message: `Missing required configuration: ${missingConfig.join(', ')}`,
+    };
+  }
+
+  // Determine installation directory
+  const extensionsDir = getExtensionsDir();
+  if (!existsSync(extensionsDir)) {
+    mkdirSync(extensionsDir, { recursive: true });
+  }
+
+  // Create unique directory for this extension
+  const mcpbBasename = basename(mcpbPath, '.mcpb');
+  const installPath = join(extensionsDir, mcpbBasename);
+
+  // Remove existing installation if present
+  if (existsSync(installPath)) {
+    log.info('[MCPB] Removing existing installation:', installPath);
+    rmSync(installPath, { recursive: true, force: true });
+  }
+
+  // Unpack MCPB
+  const unpackResult = unpackMcpb(mcpbPath, installPath);
+  if (!unpackResult.success) {
+    return {
+      success: false,
+      serverName: finalServerName,
+      message: unpackResult.error || 'Failed to unpack MCPB',
+    };
+  }
+
+  log.info('[MCPB] Unpacked to:', installPath);
+
+  // Resolve variables in mcp_config
+  const resolvedConfig = resolveServerConfig(manifest, installPath, userConfig);
+
+  const displayName = manifest.display_name || manifest.name;
+  log.info('[MCPB] Installation complete:', displayName, 'v' + manifest.version);
+
+  return {
+    success: true,
+    serverName: finalServerName,
+    message: `Successfully installed ${displayName} v${manifest.version}`,
+    installPath,
+    config: resolvedConfig,
+  };
+}
+
+/**
+ * Uninstall an MCPB extension
+ *
+ * Removes the extension directory from the extensions folder.
+ * Note: This does not remove the server configuration - that must be done separately.
+ *
+ * @param extensionName Name of the extension (directory name in extensions folder)
+ * @returns true if uninstalled successfully
+ */
+export function uninstallMcpb(extensionName: string): boolean {
+  const extensionsDir = getExtensionsDir();
+  const installPath = join(extensionsDir, extensionName);
+
+  if (!existsSync(installPath)) {
+    log.warn('[MCPB] Extension not found:', extensionName);
+    return false;
+  }
+
+  try {
+    rmSync(installPath, { recursive: true, force: true });
+    log.info('[MCPB] Uninstalled:', extensionName);
+    return true;
+  } catch (error) {
+    log.error('[MCPB] Failed to uninstall:', error);
+    return false;
+  }
+}
+
+/**
+ * Get manifest for preview display
+ *
+ * Helper to extract display-friendly manifest information
+ */
+export function getManifestDisplayInfo(manifest: McpbManifest): {
+  name: string;
+  displayName: string;
+  version: string;
+  description: string;
+  author: string;
+  tools: Array<{ name: string; description?: string }>;
+  hasUserConfig: boolean;
+  userConfigFields: Array<{
+    key: string;
+    type: string;
+    title: string;
+    description: string;
+    required: boolean;
+    sensitive: boolean;
+    default?: unknown;
+  }>;
+} {
+  const userConfigFields: Array<{
+    key: string;
+    type: string;
+    title: string;
+    description: string;
+    required: boolean;
+    sensitive: boolean;
+    default?: unknown;
+  }> = [];
+
+  if (manifest.user_config) {
+    for (const [key, option] of Object.entries(manifest.user_config)) {
+      userConfigFields.push({
+        key,
+        type: option.type,
+        title: option.title,
+        description: option.description,
+        required: option.required ?? false,
+        sensitive: option.sensitive ?? false,
+        default: resolveDefaultValue(option.default),
+      });
+    }
+  }
+
+  return {
+    name: manifest.name,
+    displayName: manifest.display_name || manifest.name,
+    version: manifest.version,
+    description: manifest.description,
+    author: manifest.author.name,
+    tools: manifest.tools || [],
+    hasUserConfig: userConfigFields.length > 0,
+    userConfigFields,
+  };
+}

--- a/src/electron/main/mcpb/manifest-parser.ts
+++ b/src/electron/main/mcpb/manifest-parser.ts
@@ -1,0 +1,215 @@
+/**
+ * MCPB Manifest Parser
+ *
+ * Parses and validates MCPB manifest.json files.
+ */
+
+import { readFileSync } from 'fs';
+import type { McpbManifest } from './types.js';
+
+export interface ParseResult {
+  success: boolean;
+  manifest?: McpbManifest;
+  error?: string;
+}
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+/**
+ * Parse manifest from JSON string
+ */
+export function parseManifest(manifestJson: string): ParseResult {
+  try {
+    const manifest = JSON.parse(manifestJson);
+    const errors = validateManifest(manifest);
+
+    if (errors.length > 0) {
+      const errorMessages = errors.map((e) => `${e.field}: ${e.message}`).join('; ');
+      return {
+        success: false,
+        error: `Invalid manifest: ${errorMessages}`,
+      };
+    }
+
+    return {
+      success: true,
+      manifest: manifest as McpbManifest,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to parse manifest JSON: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+  }
+}
+
+/**
+ * Parse manifest from file path
+ */
+export function parseManifestFile(manifestPath: string): ParseResult {
+  try {
+    const content = readFileSync(manifestPath, 'utf-8');
+    return parseManifest(content);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to read manifest file: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+  }
+}
+
+/**
+ * Validate manifest object structure
+ */
+function validateManifest(manifest: unknown): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (!manifest || typeof manifest !== 'object') {
+    errors.push({ field: 'root', message: 'Manifest must be an object' });
+    return errors;
+  }
+
+  const obj = manifest as Record<string, unknown>;
+
+  // Check manifest version
+  if (!obj.manifest_version && !obj.dxt_version) {
+    errors.push({
+      field: 'manifest_version',
+      message: 'Either manifest_version or dxt_version is required',
+    });
+  }
+
+  // Required string fields
+  const requiredStrings = ['name', 'version', 'description'];
+  for (const field of requiredStrings) {
+    if (typeof obj[field] !== 'string' || (obj[field] as string).trim() === '') {
+      errors.push({ field, message: 'Must be a non-empty string' });
+    }
+  }
+
+  // Validate author
+  if (!obj.author || typeof obj.author !== 'object') {
+    errors.push({ field: 'author', message: 'Must be an object' });
+  } else {
+    const author = obj.author as Record<string, unknown>;
+    if (typeof author.name !== 'string' || author.name.trim() === '') {
+      errors.push({ field: 'author.name', message: 'Must be a non-empty string' });
+    }
+  }
+
+  // Validate server
+  if (!obj.server || typeof obj.server !== 'object') {
+    errors.push({ field: 'server', message: 'Must be an object' });
+  } else {
+    const server = obj.server as Record<string, unknown>;
+
+    // Validate server.type
+    const validTypes = ['node', 'python', 'binary'];
+    if (!validTypes.includes(server.type as string)) {
+      errors.push({
+        field: 'server.type',
+        message: `Must be one of: ${validTypes.join(', ')}`,
+      });
+    }
+
+    // Validate server.entry_point
+    if (typeof server.entry_point !== 'string' || server.entry_point.trim() === '') {
+      errors.push({ field: 'server.entry_point', message: 'Must be a non-empty string' });
+    }
+
+    // Validate server.mcp_config
+    if (!server.mcp_config || typeof server.mcp_config !== 'object') {
+      errors.push({ field: 'server.mcp_config', message: 'Must be an object' });
+    } else {
+      const mcpConfig = server.mcp_config as Record<string, unknown>;
+      if (typeof mcpConfig.command !== 'string' || mcpConfig.command.trim() === '') {
+        errors.push({ field: 'server.mcp_config.command', message: 'Must be a non-empty string' });
+      }
+    }
+  }
+
+  // Validate user_config if present
+  if (obj.user_config !== undefined) {
+    if (typeof obj.user_config !== 'object' || obj.user_config === null) {
+      errors.push({ field: 'user_config', message: 'Must be an object' });
+    } else {
+      const userConfig = obj.user_config as Record<string, unknown>;
+      const validTypes = ['string', 'number', 'boolean', 'directory', 'file'];
+
+      for (const [key, value] of Object.entries(userConfig)) {
+        if (!value || typeof value !== 'object') {
+          errors.push({ field: `user_config.${key}`, message: 'Must be an object' });
+          continue;
+        }
+
+        const option = value as Record<string, unknown>;
+
+        if (!validTypes.includes(option.type as string)) {
+          errors.push({
+            field: `user_config.${key}.type`,
+            message: `Must be one of: ${validTypes.join(', ')}`,
+          });
+        }
+
+        if (typeof option.title !== 'string') {
+          errors.push({ field: `user_config.${key}.title`, message: 'Must be a string' });
+        }
+
+        if (typeof option.description !== 'string') {
+          errors.push({ field: `user_config.${key}.description`, message: 'Must be a string' });
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Check if manifest is compatible with current platform
+ */
+export function checkPlatformCompatibility(manifest: McpbManifest): boolean {
+  if (!manifest.compatibility?.platforms) {
+    return true; // No platform restriction
+  }
+
+  const currentPlatform = process.platform as 'darwin' | 'win32' | 'linux';
+  return manifest.compatibility.platforms.includes(currentPlatform);
+}
+
+/**
+ * Get list of required user config fields that are missing
+ */
+export function getMissingRequiredConfig(
+  manifest: McpbManifest,
+  userConfig?: Record<string, unknown>
+): string[] {
+  const missing: string[] = [];
+
+  if (!manifest.user_config) {
+    return missing;
+  }
+
+  const providedConfig = userConfig || {};
+
+  for (const [key, option] of Object.entries(manifest.user_config)) {
+    if (option.required) {
+      const value = providedConfig[key];
+
+      // Check if value is missing or empty
+      if (
+        value === undefined ||
+        value === null ||
+        value === '' ||
+        (Array.isArray(value) && (value.length === 0 || value.some((v) => v === '' || v === null)))
+      ) {
+        missing.push(key);
+      }
+    }
+  }
+
+  return missing;
+}

--- a/src/electron/main/mcpb/signature.ts
+++ b/src/electron/main/mcpb/signature.ts
@@ -1,0 +1,311 @@
+/**
+ * MCPB Signature Verification
+ *
+ * Extracts and verifies PKCS#7 code signatures from MCPB files.
+ * Adapted from mcpb-reference implementation.
+ */
+
+import { execFile } from 'child_process';
+import { readFileSync } from 'fs';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import forge from 'node-forge';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { promisify } from 'util';
+import type { McpbSignatureInfo, SignatureStatus } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+// Signature block markers
+const SIGNATURE_HEADER = 'MCPB_SIG_V1';
+const SIGNATURE_FOOTER = 'MCPB_SIG_END';
+
+/**
+ * Extract signature block from MCPB file content
+ */
+export function extractSignatureBlock(fileContent: Buffer): {
+  originalContent: Buffer;
+  pkcs7Signature?: Buffer;
+} {
+  // Look for signature footer at the end
+  const footerBytes = Buffer.from(SIGNATURE_FOOTER, 'utf-8');
+  const footerIndex = fileContent.lastIndexOf(footerBytes);
+
+  if (footerIndex === -1) {
+    return { originalContent: fileContent };
+  }
+
+  // Look for signature header before footer
+  const headerBytes = Buffer.from(SIGNATURE_HEADER, 'utf-8');
+  let headerIndex = -1;
+
+  // Search backwards from footer
+  for (let i = footerIndex - 1; i >= 0; i--) {
+    if (fileContent.slice(i, i + headerBytes.length).equals(headerBytes)) {
+      headerIndex = i;
+      break;
+    }
+  }
+
+  if (headerIndex === -1) {
+    return { originalContent: fileContent };
+  }
+
+  // Extract original content (everything before signature block)
+  const originalContent = fileContent.slice(0, headerIndex);
+
+  // Parse signature block
+  let offset = headerIndex + headerBytes.length;
+
+  try {
+    // Read PKCS#7 signature length
+    const sigLength = fileContent.readUInt32LE(offset);
+    offset += 4;
+
+    // Read PKCS#7 signature
+    const pkcs7Signature = fileContent.slice(offset, offset + sigLength);
+
+    return {
+      originalContent,
+      pkcs7Signature,
+    };
+  } catch {
+    return { originalContent: fileContent };
+  }
+}
+
+/**
+ * Verify certificate chain against OS trust store
+ */
+async function verifyCertificateChain(
+  certificate: Buffer,
+  intermediates?: Buffer[]
+): Promise<boolean> {
+  let tempDir: string | null = null;
+
+  try {
+    tempDir = await mkdtemp(join(tmpdir(), 'mcpb-verify-'));
+    const certChainPath = join(tempDir, 'chain.pem');
+    const certChain = [certificate, ...(intermediates || [])].join('\n');
+    await writeFile(certChainPath, certChain);
+
+    // Platform-specific verification
+    if (process.platform === 'darwin') {
+      try {
+        await execFileAsync('security', [
+          'verify-cert',
+          '-c',
+          certChainPath,
+          '-p',
+          'codeSign',
+        ]);
+        return true;
+      } catch {
+        return false;
+      }
+    } else if (process.platform === 'win32') {
+      const psCommand = `
+        $ErrorActionPreference = 'Stop'
+        $certCollection = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+        $certCollection.Import('${certChainPath.replace(/\\/g, '\\\\')}')
+
+        if ($certCollection.Count -eq 0) {
+          Write-Error 'No certificates found'
+          exit 1
+        }
+
+        $leafCert = $certCollection[0]
+        $chain = New-Object System.Security.Cryptography.X509Certificates.X509Chain
+
+        # Enable revocation checking
+        $chain.ChainPolicy.RevocationMode = 'Online'
+        $chain.ChainPolicy.RevocationFlag = 'EntireChain'
+        $chain.ChainPolicy.UrlRetrievalTimeout = New-TimeSpan -Seconds 30
+
+        # Add code signing application policy
+        $codeSignOid = New-Object System.Security.Cryptography.Oid '1.3.6.1.5.5.7.3.3'
+        $chain.ChainPolicy.ApplicationPolicy.Add($codeSignOid)
+
+        # Add intermediate certificates to extra store
+        for ($i = 1; $i -lt $certCollection.Count; $i++) {
+          [void]$chain.ChainPolicy.ExtraStore.Add($certCollection[$i])
+        }
+
+        # Build and validate chain
+        $result = $chain.Build($leafCert)
+
+        if ($result) {
+          'Valid'
+        } else {
+          $chain.ChainStatus | ForEach-Object {
+            Write-Error "$($_.Status): $($_.StatusInformation)"
+          }
+          exit 1
+        }
+      `.trim();
+
+      try {
+        const { stdout } = await execFileAsync('powershell.exe', [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          psCommand,
+        ]);
+        return stdout.includes('Valid');
+      } catch {
+        return false;
+      }
+    } else {
+      // Linux: Use openssl
+      try {
+        await execFileAsync('openssl', [
+          'verify',
+          '-purpose',
+          'codesigning',
+          '-CApath',
+          '/etc/ssl/certs',
+          certChainPath,
+        ]);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  } catch {
+    return false;
+  } finally {
+    if (tempDir) {
+      try {
+        await rm(tempDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+}
+
+/**
+ * Verify MCPB file signature
+ *
+ * @param mcpbPath Path to the MCPB file
+ * @returns Signature information including verification status
+ */
+export async function verifySignature(mcpbPath: string): Promise<McpbSignatureInfo> {
+  try {
+    const fileContent = readFileSync(mcpbPath);
+
+    // Find and extract signature block
+    const { originalContent, pkcs7Signature } = extractSignatureBlock(fileContent);
+
+    if (!pkcs7Signature) {
+      return { status: 'unsigned' };
+    }
+
+    // Parse PKCS#7 signature
+    const asn1 = forge.asn1.fromDer(pkcs7Signature.toString('binary'));
+    const p7Message = forge.pkcs7.messageFromAsn1(asn1);
+
+    // Verify it's signed data
+    if (
+      !('type' in p7Message) ||
+      p7Message.type !== forge.pki.oids.signedData
+    ) {
+      return { status: 'unsigned' };
+    }
+
+    // Type assertion for signed data
+    const p7 = p7Message as unknown as forge.pkcs7.PkcsSignedData & {
+      signerInfos: Array<{
+        authenticatedAttributes: Array<{
+          type: string;
+          value: unknown;
+        }>;
+      }>;
+      verify: (options?: { authenticatedAttributes?: boolean }) => boolean;
+    };
+
+    // Extract certificates from PKCS#7
+    const certificates = p7.certificates || [];
+    if (certificates.length === 0) {
+      return { status: 'unsigned' };
+    }
+
+    // Get the signing certificate (first one)
+    const signingCert = certificates[0];
+
+    // Verify PKCS#7 signature
+    // Convert Node.js Buffer to binary string for node-forge
+    const contentBuf = forge.util.createBuffer(originalContent.toString('binary'));
+
+    try {
+      p7.verify({ authenticatedAttributes: true });
+
+      // Also verify the content matches
+      const signerInfos = p7.signerInfos;
+      const signerInfo = signerInfos?.[0];
+      if (signerInfo) {
+        const md = forge.md.sha256.create();
+        md.update(contentBuf.getBytes());
+        const digest = md.digest().getBytes();
+
+        // Find the message digest attribute
+        let messageDigest = null;
+        for (const attr of signerInfo.authenticatedAttributes) {
+          if (attr.type === forge.pki.oids.messageDigest) {
+            messageDigest = attr.value;
+            break;
+          }
+        }
+
+        if (!messageDigest || messageDigest !== digest) {
+          return { status: 'unsigned' };
+        }
+      }
+    } catch {
+      return { status: 'unsigned' };
+    }
+
+    // Convert forge certificate to PEM for OS verification
+    const certPem = forge.pki.certificateToPem(signingCert);
+    const intermediatePems = certificates
+      .slice(1)
+      .map((cert) => Buffer.from(forge.pki.certificateToPem(cert)));
+
+    // Verify certificate chain against OS trust store
+    const chainValid = await verifyCertificateChain(
+      Buffer.from(certPem),
+      intermediatePems
+    );
+
+    // Extract certificate info
+    const isSelfSigned =
+      signingCert.issuer.getField('CN')?.value ===
+      signingCert.subject.getField('CN')?.value;
+
+    // Determine status
+    let status: SignatureStatus;
+    if (!chainValid) {
+      status = isSelfSigned ? 'self-signed' : 'unsigned';
+    } else {
+      status = isSelfSigned ? 'self-signed' : 'signed';
+    }
+
+    return {
+      status,
+      publisher: signingCert.subject.getField('CN')?.value || 'Unknown',
+      issuer: signingCert.issuer.getField('CN')?.value || 'Unknown',
+      valid_from: signingCert.validity.notBefore.toISOString(),
+      valid_to: signingCert.validity.notAfter.toISOString(),
+      fingerprint: forge.md.sha256
+        .create()
+        .update(
+          forge.asn1.toDer(forge.pki.certificateToAsn1(signingCert)).getBytes()
+        )
+        .digest()
+        .toHex(),
+    };
+  } catch (error) {
+    // If verification fails for any reason, treat as unsigned
+    return { status: 'unsigned' };
+  }
+}

--- a/src/electron/main/mcpb/types.ts
+++ b/src/electron/main/mcpb/types.ts
@@ -1,0 +1,178 @@
+/**
+ * MCPB (MCP Bundle) Types
+ *
+ * TypeScript interfaces for MCPB manifest schema v0.3 and related types.
+ */
+
+/**
+ * User configuration option definition in manifest
+ */
+export interface McpbUserConfigOption {
+  type: 'string' | 'number' | 'boolean' | 'directory' | 'file';
+  title: string;
+  description: string;
+  required?: boolean;
+  default?: string | number | boolean | string[];
+  multiple?: boolean;
+  sensitive?: boolean;
+  min?: number;
+  max?: number;
+}
+
+/**
+ * Tool declaration in manifest
+ */
+export interface McpbTool {
+  name: string;
+  description?: string;
+}
+
+/**
+ * Platform-specific configuration override
+ */
+export interface McpbPlatformOverride {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+/**
+ * MCP server configuration within manifest
+ */
+export interface McpbMcpConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  platform_overrides?: Record<string, McpbPlatformOverride>;
+}
+
+/**
+ * Server definition in manifest
+ */
+export interface McpbServer {
+  type: 'node' | 'python' | 'binary';
+  entry_point: string;
+  mcp_config: McpbMcpConfig;
+}
+
+/**
+ * Author information in manifest
+ */
+export interface McpbAuthor {
+  name: string;
+  email?: string;
+  url?: string;
+}
+
+/**
+ * Compatibility constraints in manifest
+ */
+export interface McpbCompatibility {
+  claude_desktop?: string;
+  platforms?: Array<'darwin' | 'win32' | 'linux'>;
+  runtimes?: {
+    python?: string;
+    node?: string;
+  };
+}
+
+/**
+ * MCPB Manifest schema v0.3
+ */
+export interface McpbManifest {
+  manifest_version?: string;
+  dxt_version?: string; // Deprecated, alias for manifest_version
+  name: string;
+  display_name?: string;
+  version: string;
+  description: string;
+  long_description?: string;
+  author: McpbAuthor;
+  repository?: {
+    type: string;
+    url: string;
+  };
+  homepage?: string;
+  documentation?: string;
+  support?: string;
+  icon?: string;
+  icons?: Array<{
+    src: string;
+    size: string;
+    theme?: string;
+  }>;
+  screenshots?: string[];
+  server: McpbServer;
+  tools?: McpbTool[];
+  tools_generated?: boolean;
+  prompts?: Array<{
+    name: string;
+    description?: string;
+    arguments?: string[];
+    text: string;
+  }>;
+  prompts_generated?: boolean;
+  keywords?: string[];
+  license?: string;
+  privacy_policies?: string[];
+  compatibility?: McpbCompatibility;
+  user_config?: Record<string, McpbUserConfigOption>;
+  _meta?: Record<string, Record<string, unknown>>;
+}
+
+/**
+ * Signature verification status
+ */
+export type SignatureStatus = 'signed' | 'self-signed' | 'unsigned';
+
+/**
+ * Signature verification result
+ */
+export interface McpbSignatureInfo {
+  status: SignatureStatus;
+  publisher?: string;
+  issuer?: string;
+  valid_from?: string;
+  valid_to?: string;
+  fingerprint?: string;
+}
+
+/**
+ * Result of previewing an MCPB file (before installation)
+ */
+export interface McpbPreviewResult {
+  mcpbPath: string;
+  manifest: McpbManifest;
+  signature: McpbSignatureInfo;
+  platformCompatible: boolean;
+  missingRequiredConfig: string[];
+}
+
+/**
+ * Options for installing an MCPB
+ */
+export interface McpbInstallOptions {
+  mcpbPath: string;
+  userConfig?: Record<string, unknown>;
+  serverName?: string;
+}
+
+/**
+ * Resolved server configuration ready for registration
+ */
+export interface ResolvedServerConfig {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+/**
+ * Result of installing an MCPB
+ */
+export interface McpbInstallResult {
+  success: boolean;
+  serverName: string;
+  message: string;
+  installPath?: string;
+  config?: ResolvedServerConfig;
+}

--- a/src/electron/main/mcpb/unpacker.ts
+++ b/src/electron/main/mcpb/unpacker.ts
@@ -1,0 +1,187 @@
+/**
+ * MCPB Unpacker
+ *
+ * Extracts MCPB (ZIP) archives with security protections.
+ * Adapted from mcpb-reference implementation.
+ */
+
+import { unzipSync } from 'fflate';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
+import { join, resolve, sep } from 'path';
+import { extractSignatureBlock } from './signature.js';
+
+export interface UnpackResult {
+  success: boolean;
+  outputDir: string;
+  error?: string;
+}
+
+/**
+ * Unpack an MCPB file to a directory
+ *
+ * Security features:
+ * - Zip-slip attack prevention via path validation
+ * - Signature block stripping before extraction
+ * - Unix permission preservation
+ *
+ * @param mcpbPath Path to the .mcpb file
+ * @param outputDir Directory to extract to
+ * @returns UnpackResult with success status and output directory
+ */
+export function unpackMcpb(mcpbPath: string, outputDir: string): UnpackResult {
+  const resolvedMcpbPath = resolve(mcpbPath);
+  const finalOutputDir = resolve(outputDir);
+
+  if (!existsSync(resolvedMcpbPath)) {
+    return {
+      success: false,
+      outputDir: finalOutputDir,
+      error: `MCPB file not found: ${mcpbPath}`,
+    };
+  }
+
+  // Create output directory if it doesn't exist
+  if (!existsSync(finalOutputDir)) {
+    mkdirSync(finalOutputDir, { recursive: true });
+  }
+
+  try {
+    const fileContent = readFileSync(resolvedMcpbPath);
+    const { originalContent } = extractSignatureBlock(fileContent);
+
+    // Parse file attributes from ZIP central directory for Unix permissions
+    const fileAttributes = new Map<string, number>();
+    const isUnix = process.platform !== 'win32';
+
+    if (isUnix) {
+      // Parse ZIP central directory to extract file attributes
+      const zipBuffer = originalContent;
+
+      // Find end of central directory record (EOCD signature: 0x06054b50)
+      let eocdOffset = -1;
+      for (let i = zipBuffer.length - 22; i >= 0; i--) {
+        if (zipBuffer.readUInt32LE(i) === 0x06054b50) {
+          eocdOffset = i;
+          break;
+        }
+      }
+
+      if (eocdOffset !== -1) {
+        const centralDirOffset = zipBuffer.readUInt32LE(eocdOffset + 16);
+        const centralDirEntries = zipBuffer.readUInt16LE(eocdOffset + 8);
+
+        let offset = centralDirOffset;
+
+        for (let i = 0; i < centralDirEntries; i++) {
+          // Central directory file header signature: 0x02014b50
+          if (zipBuffer.readUInt32LE(offset) === 0x02014b50) {
+            const externalAttrs = zipBuffer.readUInt32LE(offset + 38);
+            const filenameLength = zipBuffer.readUInt16LE(offset + 28);
+            const filename = zipBuffer.toString(
+              'utf8',
+              offset + 46,
+              offset + 46 + filenameLength
+            );
+
+            // Extract Unix permissions from external attributes (upper 16 bits)
+            const mode = (externalAttrs >> 16) & 0o777;
+            if (mode > 0) {
+              fileAttributes.set(filename, mode);
+            }
+
+            const extraFieldLength = zipBuffer.readUInt16LE(offset + 30);
+            const commentLength = zipBuffer.readUInt16LE(offset + 32);
+            offset += 46 + filenameLength + extraFieldLength + commentLength;
+          } else {
+            break;
+          }
+        }
+      }
+    }
+
+    // Decompress ZIP content
+    const decompressed = unzipSync(originalContent);
+
+    for (const relativePath in decompressed) {
+      if (Object.prototype.hasOwnProperty.call(decompressed, relativePath)) {
+        const data = decompressed[relativePath];
+        const fullPath = join(finalOutputDir, relativePath);
+
+        // SECURITY: Prevent zip slip attacks by validating the resolved path
+        const normalizedPath = resolve(fullPath);
+        const normalizedOutputDir = resolve(finalOutputDir);
+        if (
+          !normalizedPath.startsWith(normalizedOutputDir + sep) &&
+          normalizedPath !== normalizedOutputDir
+        ) {
+          return {
+            success: false,
+            outputDir: finalOutputDir,
+            error: `Path traversal attempt detected: ${relativePath}`,
+          };
+        }
+
+        // Create parent directory
+        const dir = join(fullPath, '..');
+        if (!existsSync(dir)) {
+          mkdirSync(dir, { recursive: true });
+        }
+
+        // Write file
+        writeFileSync(fullPath, data);
+
+        // Restore Unix file permissions if available
+        if (isUnix && fileAttributes.has(relativePath)) {
+          try {
+            const mode = fileAttributes.get(relativePath);
+            if (mode !== undefined) {
+              chmodSync(fullPath, mode);
+            }
+          } catch {
+            // Silently ignore permission errors
+          }
+        }
+      }
+    }
+
+    return {
+      success: true,
+      outputDir: finalOutputDir,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      outputDir: finalOutputDir,
+      error: error instanceof Error ? error.message : 'Unknown error during unpacking',
+    };
+  }
+}
+
+/**
+ * Read manifest.json from MCPB without extracting
+ *
+ * @param mcpbPath Path to the .mcpb file
+ * @returns Manifest JSON string or null if not found
+ */
+export function readManifestFromMcpb(mcpbPath: string): string | null {
+  try {
+    const fileContent = readFileSync(mcpbPath);
+    const { originalContent } = extractSignatureBlock(fileContent);
+    const decompressed = unzipSync(originalContent);
+
+    // Look for manifest.json at root
+    if (decompressed['manifest.json']) {
+      return Buffer.from(decompressed['manifest.json']).toString('utf-8');
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/electron/main/mcpb/variable-resolver.ts
+++ b/src/electron/main/mcpb/variable-resolver.ts
@@ -1,0 +1,236 @@
+/**
+ * MCPB Variable Resolver
+ *
+ * Performs variable substitution in MCPB manifest mcp_config.
+ * Adapted from mcpb-reference implementation.
+ */
+
+import { homedir } from 'os';
+import { sep } from 'path';
+import type { McpbManifest, ResolvedServerConfig } from './types.js';
+
+/**
+ * System directories for variable substitution
+ */
+export interface SystemDirs {
+  HOME: string;
+  DESKTOP?: string;
+  DOCUMENTS?: string;
+  DOWNLOADS?: string;
+}
+
+/**
+ * Get system directories for the current platform
+ */
+export function getSystemDirs(): SystemDirs {
+  const home = homedir();
+  const isWindows = process.platform === 'win32';
+
+  return {
+    HOME: home,
+    DESKTOP: isWindows
+      ? `${home}\\Desktop`
+      : `${home}/Desktop`,
+    DOCUMENTS: isWindows
+      ? `${home}\\Documents`
+      : `${home}/Documents`,
+    DOWNLOADS: isWindows
+      ? `${home}\\Downloads`
+      : `${home}/Downloads`,
+  };
+}
+
+/**
+ * Recursively replace variables in any value
+ *
+ * Handles strings, arrays, and objects.
+ * For arrays, variables that expand to arrays are expanded inline.
+ */
+function replaceVariables(
+  value: unknown,
+  variables: Record<string, string | string[]>
+): unknown {
+  if (typeof value === 'string') {
+    let result = value;
+
+    // Replace all variables in the string
+    for (const [key, replacement] of Object.entries(variables)) {
+      const pattern = new RegExp(`\\$\\{${key}\\}`, 'g');
+
+      // Check if this pattern actually exists in the string
+      if (result.match(pattern)) {
+        if (Array.isArray(replacement)) {
+          // Can't replace with array in string context - join with space
+          result = result.replace(pattern, replacement.join(' '));
+        } else {
+          result = result.replace(pattern, replacement);
+        }
+      }
+    }
+
+    return result;
+  } else if (Array.isArray(value)) {
+    // For arrays, handle special case of array expansion
+    const result: unknown[] = [];
+
+    for (const item of value) {
+      if (
+        typeof item === 'string' &&
+        item.match(/^\$\{user_config\.[^}]+\}$/)
+      ) {
+        // This is a user config variable that might expand to multiple values
+        const varName = item.match(/^\$\{([^}]+)\}$/)?.[1];
+        if (varName && variables[varName]) {
+          const replacement = variables[varName];
+          if (Array.isArray(replacement)) {
+            // Expand array inline
+            result.push(...replacement);
+          } else {
+            result.push(replacement);
+          }
+        } else {
+          // Variable not found, keep original
+          result.push(item);
+        }
+      } else {
+        // Recursively process non-variable items
+        result.push(replaceVariables(item, variables));
+      }
+    }
+
+    return result;
+  } else if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = replaceVariables(val, variables);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/**
+ * Resolve variables in manifest's mcp_config
+ *
+ * @param manifest The MCPB manifest
+ * @param extensionPath Path where the extension is installed
+ * @param userConfig User-provided configuration values
+ * @returns Resolved server configuration ready for use
+ */
+export function resolveServerConfig(
+  manifest: McpbManifest,
+  extensionPath: string,
+  userConfig?: Record<string, unknown>
+): ResolvedServerConfig {
+  const systemDirs = getSystemDirs();
+
+  // Build variables map
+  const variables: Record<string, string | string[]> = {
+    __dirname: extensionPath,
+    pathSeparator: sep,
+    '/': sep,
+    ...systemDirs,
+  };
+
+  // Build merged configuration from defaults and user settings
+  const mergedConfig: Record<string, unknown> = {};
+
+  // First, add defaults from manifest
+  if (manifest.user_config) {
+    for (const [key, configOption] of Object.entries(manifest.user_config)) {
+      if (configOption.default !== undefined) {
+        mergedConfig[key] = configOption.default;
+      }
+    }
+  }
+
+  // Then, override with user settings
+  if (userConfig) {
+    Object.assign(mergedConfig, userConfig);
+  }
+
+  // Add merged configuration variables for substitution
+  for (const [key, value] of Object.entries(mergedConfig)) {
+    const userConfigKey = `user_config.${key}`;
+
+    if (Array.isArray(value)) {
+      // Keep arrays as arrays for proper expansion
+      variables[userConfigKey] = value.map(String);
+    } else if (typeof value === 'boolean') {
+      // Convert booleans to "true"/"false" strings as per spec
+      variables[userConfigKey] = value ? 'true' : 'false';
+    } else {
+      // Convert other types to strings
+      variables[userConfigKey] = String(value);
+    }
+  }
+
+  // Get base config with platform overrides applied
+  const baseConfig = manifest.server.mcp_config;
+  let mcpConfig = {
+    command: baseConfig.command,
+    args: baseConfig.args || [],
+    env: baseConfig.env || {},
+  };
+
+  // Apply platform-specific overrides
+  if (baseConfig.platform_overrides?.[process.platform]) {
+    const override = baseConfig.platform_overrides[process.platform];
+    mcpConfig = {
+      command: override.command ?? mcpConfig.command,
+      args: override.args ?? mcpConfig.args,
+      env: override.env ?? mcpConfig.env,
+    };
+  }
+
+  // Replace variables recursively
+  const resolved = replaceVariables(mcpConfig, variables) as {
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+  };
+
+  return {
+    command: resolved.command,
+    args: resolved.args,
+    env: resolved.env,
+  };
+}
+
+/**
+ * Resolve default values for user config display
+ *
+ * Replaces system variables like ${HOME} with actual values
+ */
+export function resolveDefaultValue(
+  defaultValue: string | number | boolean | string[] | undefined,
+  extensionPath?: string
+): string | number | boolean | string[] | undefined {
+  if (defaultValue === undefined) {
+    return undefined;
+  }
+
+  if (typeof defaultValue !== 'string') {
+    return defaultValue;
+  }
+
+  const systemDirs = getSystemDirs();
+  const variables: Record<string, string> = {
+    ...systemDirs,
+    pathSeparator: sep,
+    '/': sep,
+  };
+
+  if (extensionPath) {
+    variables.__dirname = extensionPath;
+  }
+
+  let result = defaultValue;
+  for (const [key, replacement] of Object.entries(variables)) {
+    const pattern = new RegExp(`\\$\\{${key}\\}`, 'g');
+    result = result.replace(pattern, replacement);
+  }
+
+  return result;
+}

--- a/src/electron/preload/host.ts
+++ b/src/electron/preload/host.ts
@@ -288,6 +288,25 @@ const electronAPI = {
   },
 
   // ============================================
+  // MCPB Installation
+  // ============================================
+
+  getMcpbPreviewData: () => {
+    validateInvokeChannel(channels.GET_MCPB_PREVIEW_DATA);
+    return ipcRenderer.invoke(channels.GET_MCPB_PREVIEW_DATA);
+  },
+
+  confirmMcpbInstall: (mcpbPath: string, userConfig?: Record<string, unknown>) => {
+    validateInvokeChannel(channels.CONFIRM_MCPB_INSTALL);
+    return ipcRenderer.invoke(channels.CONFIRM_MCPB_INSTALL, mcpbPath, userConfig);
+  },
+
+  browsePath: (type: 'file' | 'directory') => {
+    validateInvokeChannel(channels.BROWSE_PATH);
+    return ipcRenderer.invoke(channels.BROWSE_PATH, type);
+  },
+
+  // ============================================
   // Lifecycle Event Listeners
   // ============================================
 

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -144,6 +144,19 @@ export const UPDATE_SERVER_CONFIG = 'config:update-server';
 export const REMOVE_SERVER_CONFIG = 'config:remove-server';
 
 // ============================================
+// MCPB Installation Channels
+// ============================================
+
+/** Get MCPB preview data for confirmation UI */
+export const GET_MCPB_PREVIEW_DATA = 'mcpb:get-preview-data';
+
+/** Confirm and complete MCPB installation */
+export const CONFIRM_MCPB_INSTALL = 'mcpb:confirm-install';
+
+/** Browse for file or directory (used by MCPB user config) */
+export const BROWSE_PATH = 'mcpb:browse-path';
+
+// ============================================
 // Settings Channels
 // ============================================
 
@@ -201,6 +214,10 @@ export const INVOKE_CHANNELS = [
   ADD_SERVER_CONFIG,
   UPDATE_SERVER_CONFIG,
   REMOVE_SERVER_CONFIG,
+  // MCPB installation
+  GET_MCPB_PREVIEW_DATA,
+  CONFIRM_MCPB_INSTALL,
+  BROWSE_PATH,
 ] as const;
 
 /** Channels that renderer can listen to (main → renderer events) */

--- a/src/web/static/mcpb-confirm/mcp-app.html
+++ b/src/web/static/mcpb-confirm/mcp-app.html
@@ -1,0 +1,796 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <title>Install MCPB Extension</title>
+  <style>
+    :root {
+      --bg: #1a1a2e;
+      --bg-secondary: #16213e;
+      --bg-tertiary: #0f1729;
+      --text: #e8e8e8;
+      --text-secondary: #a0a0a0;
+      --accent: #6366f1;
+      --accent-hover: #818cf8;
+      --border: #2a2a4a;
+      --success: #22c55e;
+      --warning: #eab308;
+      --error: #ef4444;
+      --info: #3b82f6;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #ffffff;
+        --bg-secondary: #f5f5f5;
+        --bg-tertiary: #e8e8e8;
+        --text: #1a1a1a;
+        --text-secondary: #666666;
+        --border: #e0e0e0;
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      padding: 16px;
+      min-height: 100vh;
+      overflow-y: auto;
+    }
+
+    .header {
+      margin-bottom: 16px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    h1 {
+      font-size: 18px;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+
+    .subtitle {
+      font-size: 12px;
+      color: var(--text-secondary);
+    }
+
+    /* Signature Badge */
+    .signature-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 500;
+      margin-bottom: 16px;
+    }
+
+    .signature-badge.signed {
+      background: rgba(34, 197, 94, 0.15);
+      color: var(--success);
+      border: 1px solid var(--success);
+    }
+
+    .signature-badge.self-signed {
+      background: rgba(234, 179, 8, 0.15);
+      color: var(--warning);
+      border: 1px solid var(--warning);
+    }
+
+    .signature-badge.unsigned {
+      background: rgba(239, 68, 68, 0.15);
+      color: var(--error);
+      border: 1px solid var(--error);
+    }
+
+    .signature-icon {
+      font-size: 14px;
+    }
+
+    .signature-details {
+      font-size: 11px;
+      color: var(--text-secondary);
+      margin-top: 4px;
+    }
+
+    /* Info Card */
+    .info-card {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px;
+      margin-bottom: 16px;
+    }
+
+    .info-row {
+      display: flex;
+      margin-bottom: 8px;
+    }
+
+    .info-row:last-child {
+      margin-bottom: 0;
+    }
+
+    .info-label {
+      width: 80px;
+      font-size: 12px;
+      color: var(--text-secondary);
+      flex-shrink: 0;
+    }
+
+    .info-value {
+      font-size: 12px;
+      word-break: break-word;
+    }
+
+    /* Tools List */
+    .tools-section {
+      margin-bottom: 16px;
+    }
+
+    .section-title {
+      font-size: 13px;
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+
+    .tools-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .tool-badge {
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 4px 8px;
+      font-size: 11px;
+      font-family: 'Fira Code', monospace;
+    }
+
+    .tools-none {
+      font-size: 12px;
+      color: var(--text-secondary);
+      font-style: italic;
+    }
+
+    /* User Config Form */
+    .config-section {
+      margin-bottom: 16px;
+    }
+
+    .form-group {
+      margin-bottom: 12px;
+    }
+
+    .form-group label {
+      display: block;
+      font-size: 12px;
+      font-weight: 500;
+      margin-bottom: 4px;
+    }
+
+    .form-group label .required {
+      color: var(--error);
+    }
+
+    .form-group input[type="text"],
+    .form-group input[type="password"],
+    .form-group input[type="number"] {
+      width: 100%;
+      padding: 8px 10px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 13px;
+      font-family: 'Fira Code', monospace;
+    }
+
+    .form-group input:focus {
+      outline: none;
+      border-color: var(--accent);
+    }
+
+    .form-group .checkbox-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .form-group input[type="checkbox"] {
+      width: 16px;
+      height: 16px;
+      accent-color: var(--accent);
+    }
+
+    .form-hint {
+      font-size: 10px;
+      color: var(--text-secondary);
+      margin-top: 4px;
+    }
+
+    .path-input-row {
+      display: flex;
+      gap: 8px;
+    }
+
+    .path-input-row input {
+      flex: 1;
+    }
+
+    .browse-btn {
+      padding: 8px 12px;
+      background: var(--bg-tertiary);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-size: 12px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+
+    .browse-btn:hover {
+      background: var(--border);
+    }
+
+    /* Warning Box */
+    .warning-box {
+      background: rgba(234, 179, 8, 0.1);
+      border: 1px solid var(--warning);
+      border-radius: 6px;
+      padding: 10px 12px;
+      margin-bottom: 16px;
+      font-size: 12px;
+      color: var(--warning);
+    }
+
+    .warning-box strong {
+      display: block;
+      margin-bottom: 4px;
+    }
+
+    /* Platform Warning */
+    .platform-error {
+      background: rgba(239, 68, 68, 0.1);
+      border: 1px solid var(--error);
+      border-radius: 6px;
+      padding: 10px 12px;
+      margin-bottom: 16px;
+      font-size: 12px;
+      color: var(--error);
+    }
+
+    /* Buttons */
+    .button-row {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      padding-top: 12px;
+      border-top: 1px solid var(--border);
+    }
+
+    .btn {
+      padding: 10px 20px;
+      border-radius: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      transition: background 0.2s;
+    }
+
+    .btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: white;
+    }
+
+    .btn-primary:hover:not(:disabled) {
+      background: var(--accent-hover);
+    }
+
+    .btn-secondary {
+      background: var(--bg-tertiary);
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+
+    .btn-secondary:hover:not(:disabled) {
+      background: var(--border);
+    }
+
+    /* Loading State */
+    .loading {
+      text-align: center;
+      padding: 40px;
+      color: var(--text-secondary);
+    }
+
+    .error {
+      text-align: center;
+      padding: 40px;
+      color: var(--error);
+    }
+
+    /* Toast */
+    .toast {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      padding: 12px 16px;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-size: 13px;
+      z-index: 200;
+      display: none;
+    }
+
+    .toast.success {
+      border-color: var(--success);
+      color: var(--success);
+    }
+
+    .toast.error {
+      border-color: var(--error);
+      color: var(--error);
+    }
+
+    .toast.visible {
+      display: block;
+      animation: slideIn 0.3s ease;
+    }
+
+    @keyframes slideIn {
+      from {
+        transform: translateX(100%);
+        opacity: 0;
+      }
+      to {
+        transform: translateX(0);
+        opacity: 1;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="content">
+    <div class="loading">Loading extension details...</div>
+  </div>
+
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // State
+    let previewData = null;
+    let userConfigValues = {};
+    let useJsonRpc = false;
+    let rpcRequestId = 1;
+    const pendingRequests = new Map();
+
+    // Get host origin
+    const hostOrigin = window.__HOST_ORIGIN__
+      || (document.referrer ? new URL(document.referrer).origin : window.location.origin);
+
+    // Detect if we're in an iframe
+    const isInIframe = window.parent !== window;
+
+    // Elements
+    const content = document.getElementById('content');
+    const toast = document.getElementById('toast');
+
+    // ============================================
+    // JSON-RPC Communication
+    // ============================================
+
+    function sendRpcRequest(method, params = {}) {
+      return new Promise((resolve, reject) => {
+        const id = rpcRequestId++;
+        pendingRequests.set(id, { resolve, reject });
+
+        window.parent.postMessage({
+          jsonrpc: '2.0',
+          id,
+          method,
+          params
+        }, '*');
+
+        setTimeout(() => {
+          if (pendingRequests.has(id)) {
+            pendingRequests.delete(id);
+            reject(new Error('Request timeout'));
+          }
+        }, 30000); // Longer timeout for installation
+      });
+    }
+
+    window.addEventListener('message', (event) => {
+      const data = event.data;
+      if (!data || typeof data !== 'object') return;
+
+      // Handle JSON-RPC response
+      if (data.jsonrpc === '2.0' && data.id && pendingRequests.has(data.id)) {
+        const { resolve, reject } = pendingRequests.get(data.id);
+        pendingRequests.delete(data.id);
+
+        if (data.error) {
+          reject(new Error(data.error.message || 'RPC error'));
+        } else {
+          resolve(data.result);
+        }
+        return;
+      }
+
+      // Handle initial data from parent
+      if (data.type === 'mcpb-preview-data') {
+        previewData = data.preview;
+        renderPreview();
+      }
+    });
+
+    // ============================================
+    // Rendering
+    // ============================================
+
+    function renderPreview() {
+      if (!previewData) {
+        content.innerHTML = '<div class="error">No preview data available</div>';
+        return;
+      }
+
+      const { manifest, signature, platformCompatible, missingRequiredConfig, mcpbPath } = previewData;
+      const displayInfo = getDisplayInfo(manifest);
+
+      // Initialize user config values with defaults
+      for (const field of displayInfo.userConfigFields) {
+        if (field.default !== undefined && field.default !== null) {
+          userConfigValues[field.key] = field.default;
+        }
+      }
+
+      let html = `
+        <div class="header">
+          <h1>Install Extension</h1>
+          <div class="subtitle">${escapeHtml(mcpbPath)}</div>
+        </div>
+
+        <!-- Signature Badge -->
+        <div class="signature-badge ${signature.status}">
+          <span class="signature-icon">${getSignatureIcon(signature.status)}</span>
+          <span>${getSignatureLabel(signature.status)}</span>
+        </div>
+        ${signature.publisher ? `<div class="signature-details">Publisher: ${escapeHtml(signature.publisher)}</div>` : ''}
+
+        <!-- Platform Warning -->
+        ${!platformCompatible ? `
+          <div class="platform-error">
+            <strong>Platform Not Supported</strong>
+            This extension is not compatible with your platform (${process.platform || 'unknown'}).
+          </div>
+        ` : ''}
+
+        <!-- Unsigned Warning -->
+        ${signature.status === 'unsigned' ? `
+          <div class="warning-box">
+            <strong>Unverified Extension</strong>
+            This extension is not signed. Only install extensions from sources you trust.
+          </div>
+        ` : ''}
+
+        <!-- Extension Info -->
+        <div class="info-card">
+          <div class="info-row">
+            <span class="info-label">Name:</span>
+            <span class="info-value">${escapeHtml(displayInfo.displayName)}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Version:</span>
+            <span class="info-value">${escapeHtml(displayInfo.version)}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Author:</span>
+            <span class="info-value">${escapeHtml(displayInfo.author)}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Description:</span>
+            <span class="info-value">${escapeHtml(displayInfo.description)}</span>
+          </div>
+        </div>
+
+        <!-- Tools -->
+        <div class="tools-section">
+          <div class="section-title">Tools (${displayInfo.tools.length})</div>
+          ${displayInfo.tools.length > 0 ? `
+            <div class="tools-list">
+              ${displayInfo.tools.map(t => `<span class="tool-badge">${escapeHtml(t.name)}</span>`).join('')}
+            </div>
+          ` : '<div class="tools-none">No tools declared (may provide tools at runtime)</div>'}
+        </div>
+
+        <!-- User Configuration -->
+        ${displayInfo.hasUserConfig ? `
+          <div class="config-section">
+            <div class="section-title">Configuration</div>
+            ${displayInfo.userConfigFields.map(field => renderConfigField(field)).join('')}
+          </div>
+        ` : ''}
+
+        <!-- Buttons -->
+        <div class="button-row">
+          <button class="btn btn-secondary" onclick="cancel()">Cancel</button>
+          <button class="btn btn-primary" id="install-btn" onclick="install()" ${!platformCompatible ? 'disabled' : ''}>
+            Install
+          </button>
+        </div>
+      `;
+
+      content.innerHTML = html;
+
+      // Add event listeners to form fields
+      for (const field of displayInfo.userConfigFields) {
+        const input = document.getElementById(`config-${field.key}`);
+        if (input) {
+          input.addEventListener('change', (e) => {
+            updateConfigValue(field.key, field.type, e.target);
+          });
+          input.addEventListener('input', (e) => {
+            updateConfigValue(field.key, field.type, e.target);
+            validateForm();
+          });
+        }
+      }
+
+      validateForm();
+    }
+
+    function renderConfigField(field) {
+      const inputId = `config-${field.key}`;
+      const required = field.required ? '<span class="required">*</span>' : '';
+      const defaultValue = field.default !== undefined ? field.default : '';
+
+      switch (field.type) {
+        case 'boolean':
+          return `
+            <div class="form-group">
+              <div class="checkbox-row">
+                <input type="checkbox" id="${inputId}" ${defaultValue ? 'checked' : ''}>
+                <label for="${inputId}">${escapeHtml(field.title)} ${required}</label>
+              </div>
+              <div class="form-hint">${escapeHtml(field.description)}</div>
+            </div>
+          `;
+
+        case 'number':
+          return `
+            <div class="form-group">
+              <label for="${inputId}">${escapeHtml(field.title)} ${required}</label>
+              <input type="number" id="${inputId}" value="${defaultValue}"
+                ${field.min !== undefined ? `min="${field.min}"` : ''}
+                ${field.max !== undefined ? `max="${field.max}"` : ''}>
+              <div class="form-hint">${escapeHtml(field.description)}</div>
+            </div>
+          `;
+
+        case 'directory':
+        case 'file':
+          return `
+            <div class="form-group">
+              <label for="${inputId}">${escapeHtml(field.title)} ${required}</label>
+              <div class="path-input-row">
+                <input type="text" id="${inputId}" value="${escapeHtml(String(defaultValue))}" placeholder="Enter path...">
+                <button class="browse-btn" onclick="browsePath('${field.key}', '${field.type}')">Browse</button>
+              </div>
+              <div class="form-hint">${escapeHtml(field.description)}</div>
+            </div>
+          `;
+
+        case 'string':
+        default:
+          const inputType = field.sensitive ? 'password' : 'text';
+          return `
+            <div class="form-group">
+              <label for="${inputId}">${escapeHtml(field.title)} ${required}</label>
+              <input type="${inputType}" id="${inputId}" value="${escapeHtml(String(defaultValue))}"
+                placeholder="${field.sensitive ? 'Enter value...' : ''}">
+              <div class="form-hint">${escapeHtml(field.description)}</div>
+            </div>
+          `;
+      }
+    }
+
+    function updateConfigValue(key, type, input) {
+      if (type === 'boolean') {
+        userConfigValues[key] = input.checked;
+      } else if (type === 'number') {
+        userConfigValues[key] = input.value ? Number(input.value) : undefined;
+      } else {
+        userConfigValues[key] = input.value || undefined;
+      }
+    }
+
+    function validateForm() {
+      if (!previewData) return;
+
+      const displayInfo = getDisplayInfo(previewData.manifest);
+      const installBtn = document.getElementById('install-btn');
+      if (!installBtn) return;
+
+      // Check all required fields
+      let valid = true;
+      for (const field of displayInfo.userConfigFields) {
+        if (field.required) {
+          const value = userConfigValues[field.key];
+          if (value === undefined || value === null || value === '') {
+            valid = false;
+            break;
+          }
+        }
+      }
+
+      installBtn.disabled = !valid || !previewData.platformCompatible;
+    }
+
+    function getDisplayInfo(manifest) {
+      const userConfigFields = [];
+
+      if (manifest.user_config) {
+        for (const [key, option] of Object.entries(manifest.user_config)) {
+          userConfigFields.push({
+            key,
+            type: option.type,
+            title: option.title,
+            description: option.description,
+            required: option.required || false,
+            sensitive: option.sensitive || false,
+            default: option.default,
+            min: option.min,
+            max: option.max,
+          });
+        }
+      }
+
+      return {
+        name: manifest.name,
+        displayName: manifest.display_name || manifest.name,
+        version: manifest.version,
+        description: manifest.description,
+        author: manifest.author?.name || 'Unknown',
+        tools: manifest.tools || [],
+        hasUserConfig: userConfigFields.length > 0,
+        userConfigFields,
+      };
+    }
+
+    function getSignatureIcon(status) {
+      switch (status) {
+        case 'signed': return '&#10004;'; // Checkmark
+        case 'self-signed': return '&#9888;'; // Warning
+        case 'unsigned': return '&#10006;'; // X
+        default: return '?';
+      }
+    }
+
+    function getSignatureLabel(status) {
+      switch (status) {
+        case 'signed': return 'Signed by trusted publisher';
+        case 'self-signed': return 'Self-signed certificate';
+        case 'unsigned': return 'Not signed';
+        default: return 'Unknown';
+      }
+    }
+
+    // ============================================
+    // Actions
+    // ============================================
+
+    async function install() {
+      if (!previewData) return;
+
+      const installBtn = document.getElementById('install-btn');
+      if (installBtn) {
+        installBtn.disabled = true;
+        installBtn.textContent = 'Installing...';
+      }
+
+      try {
+        // Clean up userConfigValues - remove undefined values
+        const cleanConfig = {};
+        for (const [key, value] of Object.entries(userConfigValues)) {
+          if (value !== undefined && value !== null && value !== '') {
+            cleanConfig[key] = value;
+          }
+        }
+
+        await sendRpcRequest('mcpb/confirmInstall', {
+          mcpbPath: previewData.mcpbPath,
+          userConfig: cleanConfig,
+        });
+
+        showToast('Extension installed successfully!', 'success');
+
+        // Close after a short delay
+        setTimeout(() => {
+          sendRpcRequest('mcpb/close');
+        }, 1500);
+      } catch (err) {
+        showToast(err.message || 'Installation failed', 'error');
+        if (installBtn) {
+          installBtn.disabled = false;
+          installBtn.textContent = 'Install';
+        }
+      }
+    }
+
+    function cancel() {
+      sendRpcRequest('mcpb/close');
+    }
+
+    async function browsePath(key, type) {
+      try {
+        const result = await sendRpcRequest('mcpb/browsePath', { type });
+        if (result && result.path) {
+          const input = document.getElementById(`config-${key}`);
+          if (input) {
+            input.value = result.path;
+            userConfigValues[key] = result.path;
+            validateForm();
+          }
+        }
+      } catch (err) {
+        console.error('Browse failed:', err);
+      }
+    }
+
+    // ============================================
+    // Utilities
+    // ============================================
+
+    function escapeHtml(str) {
+      if (!str) return '';
+      return String(str).replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+      })[c]);
+    }
+
+    function showToast(message, type = 'success') {
+      toast.textContent = message;
+      toast.className = `toast ${type} visible`;
+      setTimeout(() => {
+        toast.classList.remove('visible');
+      }, 3000);
+    }
+
+    // ============================================
+    // Initialize
+    // ============================================
+
+    if (isInIframe) {
+      useJsonRpc = true;
+      // Request preview data from parent
+      sendRpcRequest('mcpb/getPreviewData').then(data => {
+        previewData = data;
+        renderPreview();
+      }).catch(err => {
+        content.innerHTML = `<div class="error">Failed to load preview: ${escapeHtml(err.message)}</div>`;
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds built-in tool `server-config__install-mcpb` that accepts a file path to an `.mcpb` file
- Verifies PKCS#7 signatures and shows signature status (signed/self-signed/unsigned)
- Shows confirmation UI with manifest details before installing
- Extracts bundle to `{userData}/extensions/` and registers the server

## Features

### MCPB Module (`src/electron/main/mcpb/`)
- **types.ts**: TypeScript interfaces for manifest schema v0.3
- **signature.ts**: Platform-specific PKCS#7 signature verification
- **unpacker.ts**: ZIP extraction with zip-slip attack protection
- **manifest-parser.ts**: Manifest validation and platform compatibility checks
- **variable-resolver.ts**: Variable substitution (`${__dirname}`, `${HOME}`, `${user_config.X}`)
- **index.ts**: Main installer with preview and install functions

### Confirmation UI (`src/web/static/mcpb-confirm/`)
- Displays manifest info (name, version, author, description, tools list)
- Shows signature status badge with visual indicator
- Renders dynamic form fields for `user_config` options
- Supports input types: string, number, boolean, directory, file

### IPC Integration
- New channels: `mcpb:get-preview-data`, `mcpb:confirm-install`, `mcpb:browse-path`
- Preload API methods for renderer communication
- IPC handlers with Electron dialog integration for file/directory browsing

## Dependencies Added
- `fflate`: Pure JS ZIP library for bundle extraction
- `node-forge`: PKCS#7 signature verification

## Test plan
- [x] Create test MCPB bundle from server-everything
- [x] Verify confirmation UI displays manifest correctly
- [x] Verify unsigned bundle shows warning
- [x] Verify installation extracts to correct location
- [x] Verify server registers and starts successfully

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)