### PR TITLE
feat: implement content annotation audience filtering

### DIFF
--- a/src/electron/main/mcp-manager.ts
+++ b/src/electron/main/mcp-manager.ts
@@ -944,6 +944,7 @@ export class McpManager {
         hasUi: !!uiResourceUri,
         uiResourceUri,
         serverName: tool.serverName,
+        annotations: tool.annotations,
       };
     });
   }

--- a/src/renderer/chat/components/ToolCallBlock.tsx
+++ b/src/renderer/chat/components/ToolCallBlock.tsx
@@ -10,6 +10,8 @@ import { useState } from 'react';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import type { ChatToolCall } from '../types';
 import { useToolExecution } from '../hooks';
+import { isForUser } from '../../../shared/content-annotations.js';
+import type { AnnotatedContentItem } from '../../../shared/types.js';
 
 interface ToolCallBlockProps {
   toolCall: ChatToolCall;
@@ -88,6 +90,52 @@ const statusLabels: Record<ChatToolCall['status'], string> = {
   failed: 'Failed',
 };
 
+/**
+ * Filter tool result content by audience for UI display.
+ * Only shows content intended for the user.
+ */
+function filterContentForUser(content: unknown): unknown {
+  // If not an array, return as-is (no annotations to filter)
+  if (!Array.isArray(content)) {
+    return content;
+  }
+
+  // Filter array items by audience
+  const filtered = content.filter((item) => {
+    // If item doesn't have annotations structure, include it (default: both audiences)
+    if (typeof item !== 'object' || item === null) {
+      return true;
+    }
+    const annotatedItem = item as AnnotatedContentItem;
+    return isForUser(annotatedItem.annotations);
+  });
+
+  return filtered;
+}
+
+/**
+ * Format filtered content for display.
+ */
+function formatContentForDisplay(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    // Extract text from content items
+    const texts = content
+      .map((item) => {
+        if (typeof item === 'string') return item;
+        if (typeof item === 'object' && item !== null && 'text' in item) {
+          return (item as { text: string }).text;
+        }
+        return JSON.stringify(item, null, 2);
+      })
+      .filter(Boolean);
+    return texts.join('\n');
+  }
+  return JSON.stringify(content, null, 2);
+}
+
 export function ToolCallBlock({ toolCall, messageId }: ToolCallBlockProps) {
   const [isOpen, setIsOpen] = useState(false);
   const { executeTool } = useToolExecution();
@@ -147,20 +195,22 @@ export function ToolCallBlock({ toolCall, messageId }: ToolCallBlockProps) {
           </div>
         )}
 
-        {toolCall.result !== undefined && (
-          <div className="tool-call-section">
-            <div className="tool-call-section-label">
-              {toolCall.result.isError ? 'Error:' : 'Result:'}
+        {toolCall.result !== undefined && (() => {
+          const filteredContent = filterContentForUser(toolCall.result.content);
+          const displayText = formatContentForDisplay(filteredContent);
+          // Don't show empty result section if all content was filtered out
+          if (!displayText) return null;
+          return (
+            <div className="tool-call-section">
+              <div className="tool-call-section-label">
+                {toolCall.result.isError ? 'Error:' : 'Result:'}
+              </div>
+              <pre className={toolCall.result.isError ? 'tool-call-error' : ''}>
+                {displayText}
+              </pre>
             </div>
-            <pre
-              className={toolCall.result.isError ? 'tool-call-error' : ''}
-            >
-              {typeof toolCall.result.content === 'string'
-                ? toolCall.result.content
-                : JSON.stringify(toolCall.result.content, null, 2)}
-            </pre>
-          </div>
-        )}
+          );
+        })()}
       </Collapsible.Content>
     </Collapsible.Root>
   );

--- a/src/renderer/chat/context/ChatContext.tsx
+++ b/src/renderer/chat/context/ChatContext.tsx
@@ -29,7 +29,8 @@ import type {
 } from '../types';
 import { useSettings } from '../../settings';
 import { useCommunication } from '../../hooks/useCommunication';
-import type { StreamEvent } from '../../../shared/types';
+import type { StreamEvent, AnnotatedContentItem } from '../../../shared/types';
+import { isForAssistant } from '../../../shared/content-annotations.js';
 
 // ============================================
 // Initial State
@@ -41,6 +42,29 @@ function generateId(): string {
 
 function generateSessionId(): string {
   return `session-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Filter tool result content by audience for LLM context.
+ * Only includes content intended for the assistant/LLM.
+ */
+function filterContentForAssistant(content: unknown): unknown {
+  // If not an array, return as-is (no annotations to filter)
+  if (!Array.isArray(content)) {
+    return content;
+  }
+
+  // Filter array items by audience
+  const filtered = content.filter((item) => {
+    // If item doesn't have annotations structure, include it (default: both audiences)
+    if (typeof item !== 'object' || item === null) {
+      return true;
+    }
+    const annotatedItem = item as AnnotatedContentItem;
+    return isForAssistant(annotatedItem.annotations);
+  });
+
+  return filtered;
 }
 
 const initialState: ChatState = {
@@ -404,12 +428,13 @@ export function ChatProvider({ children }: ChatProviderProps) {
               }
 
               // Add tool result message for completed calls
+              // Filter content by audience - only include assistant-targeted content
               if (completedCalls.length > 0) {
                 const toolResults = completedCalls.map((tc) => ({
                   type: 'tool-result',
                   toolCallId: tc.id,
                   toolName: tc.qualifiedName,
-                  result: tc.result!.content,
+                  result: filterContentForAssistant(tc.result!.content),
                   isError: tc.result!.isError,
                 }));
                 chatMessages.push({ role: 'tool', content: toolResults });
@@ -569,12 +594,13 @@ export function ChatProvider({ children }: ChatProviderProps) {
               }
 
               // Add tool result message for completed calls
+              // Filter content by audience - only include assistant-targeted content
               if (completedCalls.length > 0) {
                 const toolResults = completedCalls.map((tc) => ({
                   type: 'tool-result',
                   toolCallId: tc.id,
                   toolName: tc.qualifiedName,
-                  result: tc.result!.content,
+                  result: filterContentForAssistant(tc.result!.content),
                   isError: tc.result!.isError,
                 }));
                 chatMessages.push({ role: 'tool', content: toolResults });

--- a/src/shared/content-annotations.ts
+++ b/src/shared/content-annotations.ts
@@ -1,0 +1,50 @@
+/**
+ * Content Annotations Utilities
+ *
+ * Provides functions for handling MCP content annotations,
+ * particularly audience-based filtering of tool result content.
+ */
+
+import type { ContentAnnotations } from './types.js';
+
+/**
+ * Sensible default when annotations not provided.
+ * Content goes to both user and assistant.
+ */
+const DEFAULT_AUDIENCE: readonly ('user' | 'assistant')[] = ['user', 'assistant'];
+
+/**
+ * Get the audience for content, with sensible default.
+ */
+export function getAudience(
+  annotations?: ContentAnnotations
+): Array<'user' | 'assistant'> {
+  return annotations?.audience ?? [...DEFAULT_AUDIENCE];
+}
+
+/**
+ * Check if content is intended for the user.
+ */
+export function isForUser(annotations?: ContentAnnotations): boolean {
+  return getAudience(annotations).includes('user');
+}
+
+/**
+ * Check if content is intended for the assistant/LLM.
+ */
+export function isForAssistant(annotations?: ContentAnnotations): boolean {
+  return getAudience(annotations).includes('assistant');
+}
+
+/**
+ * Filter content items by audience.
+ * Items without annotations default to both audiences.
+ */
+export function filterContentByAudience<
+  T extends { annotations?: ContentAnnotations },
+>(items: T[], audience: 'user' | 'assistant'): T[] {
+  return items.filter((item) => {
+    const itemAudience = getAudience(item.annotations);
+    return itemAudience.includes(audience);
+  });
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -108,6 +108,18 @@ export interface ContentAnnotations {
   lastModified?: string;
 }
 
+/**
+ * Content item with optional annotations.
+ * Used for tool result content that may have audience/priority hints.
+ */
+export interface AnnotatedContentItem {
+  type: 'text' | 'image' | 'resource';
+  text?: string;
+  data?: string;
+  mimeType?: string;
+  annotations?: ContentAnnotations;
+}
+
 export interface ToolWithUIInfo {
   /** Qualified name for API calls (server__tool) */
   name: string;


### PR DESCRIPTION
## Summary
- Implements MCP content annotation support for filtering tool results by audience
- Content with `audience: ['user']` is shown in UI only (excluded from LLM context)
- Content with `audience: ['assistant']` is sent to LLM only (hidden from UI)
- Content without annotations defaults to both audiences (backward compatible)

## Changes
- Added `src/shared/content-annotations.ts` with filtering utilities
- Added `AnnotatedContentItem` type to shared types
- Updated `ToolCallBlock.tsx` to filter UI display by user audience
- Updated `ChatContext.tsx` to filter LLM context by assistant audience
- Updated `mcp-manager.ts` to pass tool annotations through

Closes #22

## Test plan
- [ ] Run `npm run electron:dev` to start the app
- [ ] Test with MCP server that returns annotated content
- [ ] Verify content with `audience: ['user']` appears in UI but not in LLM responses
- [ ] Verify content with `audience: ['assistant']` doesn't appear in UI but affects LLM
- [ ] Verify existing tools without annotations work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)