### PR TITLE
feat: add pi coding agent integration

### DIFF
--- a/src/communication/types.ts
+++ b/src/communication/types.ts
@@ -162,7 +162,7 @@ export interface ElectronAPI {
 
   // Coding Agent
   codingAgent: {
-    start(config: { cwd: string; provider?: string; model?: string; cliPath?: string; env?: Record<string, string> }): Promise<void>;
+    start(config: { cwd?: string; provider?: string; model?: string; cliPath?: string; env?: Record<string, string> }): Promise<void>;
     execute(task: string): Promise<void>;
     steer(message: string): Promise<void>;
     abort(): Promise<void>;

--- a/src/communication/types.ts
+++ b/src/communication/types.ts
@@ -162,7 +162,7 @@ export interface ElectronAPI {
 
   // Coding Agent
   codingAgent: {
-    start(config: { cwd?: string; provider?: string; model?: string; cliPath?: string; env?: Record<string, string> }): Promise<void>;
+    start(config: { cwd?: string; provider?: string; model?: string; cliPath?: string; env?: Record<string, string> }): Promise<void>; // env vars are filtered through an allowlist in the main process
     execute(task: string): Promise<void>;
     steer(message: string): Promise<void>;
     abort(): Promise<void>;

--- a/src/communication/types.ts
+++ b/src/communication/types.ts
@@ -159,6 +159,17 @@ export interface ElectronAPI {
   minimizeWindow(): void;
   maximizeWindow(): void;
   closeWindow(): void;
+
+  // Coding Agent
+  codingAgent: {
+    start(config: { cwd: string; provider?: string; model?: string; cliPath?: string; env?: Record<string, string> }): Promise<void>;
+    execute(task: string): Promise<void>;
+    steer(message: string): Promise<void>;
+    abort(): Promise<void>;
+    stop(): Promise<void>;
+    respondToUIRequest(response: { type: string; id: string; [key: string]: unknown }): Promise<void>;
+    onEvent(callback: (event: Record<string, unknown>) => void): () => void;
+  };
 }
 
 // Extend Window interface for TypeScript

--- a/src/electron/main/coding-agent/adapter.ts
+++ b/src/electron/main/coding-agent/adapter.ts
@@ -21,8 +21,10 @@ export interface CodingAgentConfig {
   model?: string;
   /** Environment variables (e.g. API keys) */
   env?: Record<string, string>;
-  /** Timeout in ms. Default: 300000 (5 min) */
+  /** Startup timeout in ms. Default: 5000 */
   timeout?: number;
+  /** Execution timeout in ms. Default: 1800000 (30 min) */
+  executionTimeout?: number;
 }
 
 // ============================================

--- a/src/electron/main/coding-agent/adapter.ts
+++ b/src/electron/main/coding-agent/adapter.ts
@@ -81,6 +81,9 @@ export interface CodingAgentAdapter {
   /** Check if agent is currently running a task */
   isRunning(): boolean;
 
+  /** Check if the agent process is still alive */
+  isProcessAlive(): boolean;
+
   /** Respond to an extension UI request from the agent */
   respondToUIRequest(response: ExtensionUIResponse): Promise<void>;
 }

--- a/src/electron/main/coding-agent/adapter.ts
+++ b/src/electron/main/coding-agent/adapter.ts
@@ -13,8 +13,8 @@
 export interface CodingAgentConfig {
   /** Path to pi CLI. Default: 'pi' (searches PATH) */
   cliPath?: string;
-  /** Working directory for the agent */
-  cwd: string;
+  /** Working directory for the agent. Defaults to main process cwd. */
+  cwd?: string;
   /** LLM provider override (uses pi's default if omitted) */
   provider?: string;
   /** Model ID override (uses pi's default if omitted) */

--- a/src/electron/main/coding-agent/adapter.ts
+++ b/src/electron/main/coding-agent/adapter.ts
@@ -88,4 +88,7 @@ export interface CodingAgentAdapter {
 
   /** Respond to an extension UI request from the agent */
   respondToUIRequest(response: ExtensionUIResponse): Promise<void>;
+
+  /** Return the config used to start this adapter (for detecting config changes) */
+  getActiveConfig(): CodingAgentConfig | null;
 }

--- a/src/electron/main/coding-agent/adapter.ts
+++ b/src/electron/main/coding-agent/adapter.ts
@@ -1,0 +1,88 @@
+/**
+ * Coding Agent Adapter
+ *
+ * Interface and types for the coding agent integration.
+ * The adapter abstracts the agent backend (pi subprocess via RPC,
+ * or potentially a direct SDK integration in the future).
+ */
+
+// ============================================
+// Configuration
+// ============================================
+
+export interface CodingAgentConfig {
+  /** Path to pi CLI. Default: 'pi' (searches PATH) */
+  cliPath?: string;
+  /** Working directory for the agent */
+  cwd: string;
+  /** LLM provider override (uses pi's default if omitted) */
+  provider?: string;
+  /** Model ID override (uses pi's default if omitted) */
+  model?: string;
+  /** Extra CLI args passed to pi */
+  args?: string[];
+  /** Environment variables (e.g. API keys) */
+  env?: Record<string, string>;
+  /** Timeout in ms. Default: 300000 (5 min) */
+  timeout?: number;
+}
+
+// ============================================
+// Agent Events (normalized from pi RPC events)
+// ============================================
+
+export type AgentEvent =
+  | { type: 'text_delta'; delta: string }
+  | { type: 'thinking_delta'; delta: string }
+  | { type: 'tool_start'; toolCallId: string; toolName: string; args: Record<string, unknown> }
+  | { type: 'tool_update'; toolCallId: string; partialResult: unknown }
+  | { type: 'tool_end'; toolCallId: string; toolName: string; result: unknown; isError: boolean }
+  | { type: 'status'; message: string; detail?: Record<string, unknown> }
+  | { type: 'complete'; usage?: AgentUsage }
+  | { type: 'error'; message: string }
+  | { type: 'set_status'; statusKey: string; statusText: string | undefined }
+  | { type: 'set_widget'; widgetKey: string; widgetLines: string[] | undefined; widgetPlacement?: string }
+  | { type: 'set_title'; title: string }
+  | { type: 'ui_request'; id: string; method: string; [key: string]: unknown };
+
+export interface AgentUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalCost: number;
+}
+
+// ============================================
+// Extension UI Response Types
+// ============================================
+
+export type ExtensionUIResponse =
+  | { type: 'extension_ui_response'; id: string; value: string }
+  | { type: 'extension_ui_response'; id: string; confirmed: boolean }
+  | { type: 'extension_ui_response'; id: string; cancelled: true };
+
+// ============================================
+// Adapter Interface
+// ============================================
+
+export interface CodingAgentAdapter {
+  /** Start the agent process */
+  start(config: CodingAgentConfig): Promise<void>;
+
+  /** Execute a coding task. Returns an async iterable of events. */
+  execute(task: string): AsyncIterable<AgentEvent>;
+
+  /** Steer the agent mid-run */
+  steer(message: string): Promise<void>;
+
+  /** Abort the current task */
+  abort(): Promise<void>;
+
+  /** Stop the agent process entirely */
+  stop(): Promise<void>;
+
+  /** Check if agent is currently running a task */
+  isRunning(): boolean;
+
+  /** Respond to an extension UI request from the agent */
+  respondToUIRequest(response: ExtensionUIResponse): Promise<void>;
+}

--- a/src/electron/main/coding-agent/adapter.ts
+++ b/src/electron/main/coding-agent/adapter.ts
@@ -19,8 +19,6 @@ export interface CodingAgentConfig {
   provider?: string;
   /** Model ID override (uses pi's default if omitted) */
   model?: string;
-  /** Extra CLI args passed to pi */
-  args?: string[];
   /** Environment variables (e.g. API keys) */
   env?: Record<string, string>;
   /** Timeout in ms. Default: 300000 (5 min) */

--- a/src/electron/main/coding-agent/handler.ts
+++ b/src/electron/main/coding-agent/handler.ts
@@ -27,7 +27,8 @@ export function registerCodingAgentHandlers(win: BrowserWindow): void {
       await adapter.stop();
     }
     adapter = createPiAdapter();
-    await adapter.start(config);
+    // Default cwd to main process working directory (renderer can't access process.cwd)
+    await adapter.start({ ...config, cwd: config.cwd || process.cwd() });
   });
 
   ipcMain.handle(AGENT_EXECUTE, async (_event, task: string) => {

--- a/src/electron/main/coding-agent/handler.ts
+++ b/src/electron/main/coding-agent/handler.ts
@@ -35,6 +35,7 @@ export function registerCodingAgentHandlers(win: BrowserWindow): void {
 
   ipcMain.handle(AGENT_EXECUTE, async (_event, task: string) => {
     if (!adapter) throw new Error('Coding agent not started');
+    if (adapter.isRunning()) throw new Error('Agent is already executing a task');
 
     for await (const event of adapter.execute(task)) {
       if (!win.isDestroyed()) {

--- a/src/electron/main/coding-agent/handler.ts
+++ b/src/electron/main/coding-agent/handler.ts
@@ -1,0 +1,72 @@
+/**
+ * Coding Agent IPC Handlers
+ *
+ * Registers IPC handlers for the coding agent lifecycle.
+ * Streams agent events to the renderer via the AGENT_EVENT channel.
+ */
+
+import { ipcMain, type BrowserWindow } from 'electron';
+import { createPiAdapter } from './pi-adapter.js';
+import type { CodingAgentAdapter, CodingAgentConfig, ExtensionUIResponse } from './adapter.js';
+import {
+  AGENT_START,
+  AGENT_EXECUTE,
+  AGENT_STEER,
+  AGENT_ABORT,
+  AGENT_STOP,
+  AGENT_UI_RESPONSE,
+  AGENT_EVENT,
+} from '../../../shared/channels.js';
+
+let adapter: CodingAgentAdapter | null = null;
+
+export function registerCodingAgentHandlers(win: BrowserWindow): void {
+  ipcMain.handle(AGENT_START, async (_event, config: CodingAgentConfig) => {
+    // Stop any existing adapter before starting a new one
+    if (adapter) {
+      await adapter.stop();
+    }
+    adapter = createPiAdapter();
+    await adapter.start(config);
+  });
+
+  ipcMain.handle(AGENT_EXECUTE, async (_event, task: string) => {
+    if (!adapter) throw new Error('Coding agent not started');
+
+    for await (const event of adapter.execute(task)) {
+      if (!win.isDestroyed()) {
+        win.webContents.send(AGENT_EVENT, event);
+      }
+    }
+  });
+
+  ipcMain.handle(AGENT_STEER, async (_event, message: string) => {
+    if (!adapter) throw new Error('Coding agent not started');
+    await adapter.steer(message);
+  });
+
+  ipcMain.handle(AGENT_ABORT, async () => {
+    if (!adapter) throw new Error('Coding agent not started');
+    await adapter.abort();
+  });
+
+  ipcMain.handle(AGENT_STOP, async () => {
+    if (adapter) {
+      await adapter.stop();
+      adapter = null;
+    }
+  });
+
+  ipcMain.handle(AGENT_UI_RESPONSE, async (_event, response: ExtensionUIResponse) => {
+    if (!adapter) throw new Error('Coding agent not started');
+    await adapter.respondToUIRequest(response);
+  });
+}
+
+/** Gracefully stop the coding agent (call from app before-quit) */
+export async function shutdownCodingAgent(): Promise<void> {
+  if (adapter) {
+    await adapter.stop();
+    adapter = null;
+  }
+}

--- a/src/electron/main/coding-agent/handler.ts
+++ b/src/electron/main/coding-agent/handler.ts
@@ -23,6 +23,25 @@ import {
 let adapter: CodingAgentAdapter | null = null;
 let starting = false;
 
+/**
+ * Compare process-affecting config fields. Returns true if the new config
+ * requires restarting the pi subprocess (different provider, model, env, or cwd).
+ * Timeout/executionTimeout are per-execution and don't require a restart.
+ */
+function processConfigChanged(
+  active: CodingAgentConfig | null,
+  incoming: CodingAgentConfig
+): boolean {
+  if (!active) return true;
+  if (active.provider !== incoming.provider) return true;
+  if (active.model !== incoming.model) return true;
+  if (active.cwd !== (incoming.cwd || process.cwd())) return true;
+  // Compare env by serialized value (both are small Record<string, string>)
+  const activeEnv = JSON.stringify(active.env ?? {});
+  const incomingEnv = JSON.stringify(incoming.env ?? {});
+  return activeEnv !== incomingEnv;
+}
+
 export function registerCodingAgentHandlers(win: BrowserWindow): void {
   ipcMain.handle(AGENT_START, async (_event, config: CodingAgentConfig) => {
     // Guard against concurrent start() calls — ipcMain.handle does NOT
@@ -30,9 +49,13 @@ export function registerCodingAgentHandlers(win: BrowserWindow): void {
     if (starting) return;
     starting = true;
     try {
-      // Reuse existing adapter if its process is alive and idle
+      // Reuse existing adapter if its process is alive, idle, and config unchanged
       if (adapter && adapter.isProcessAlive() && !adapter.isRunning()) {
-        return;
+        if (!processConfigChanged(adapter.getActiveConfig(), config)) {
+          return;
+        }
+        // Config changed — stop existing process so a new one starts with updated settings
+        await adapter.stop();
       }
       // Stop any existing adapter before starting a new one
       if (adapter) {

--- a/src/electron/main/coding-agent/handler.ts
+++ b/src/electron/main/coding-agent/handler.ts
@@ -24,6 +24,10 @@ let adapter: CodingAgentAdapter | null = null;
 
 export function registerCodingAgentHandlers(win: BrowserWindow): void {
   ipcMain.handle(AGENT_START, async (_event, config: CodingAgentConfig) => {
+    // Reuse existing adapter if its process is alive and idle
+    if (adapter && adapter.isProcessAlive() && !adapter.isRunning()) {
+      return;
+    }
     // Stop any existing adapter before starting a new one
     if (adapter) {
       await adapter.stop();
@@ -37,10 +41,21 @@ export function registerCodingAgentHandlers(win: BrowserWindow): void {
     if (!adapter) throw new Error('Coding agent not started');
     if (adapter.isRunning()) throw new Error('Agent is already executing a task');
 
-    for await (const event of adapter.execute(task)) {
-      if (!win.isDestroyed()) {
-        win.webContents.send(AGENT_EVENT, event);
+    try {
+      for await (const event of adapter.execute(task)) {
+        if (!win.isDestroyed()) {
+          win.webContents.send(AGENT_EVENT, event);
+        }
       }
+    } catch (err) {
+      // Ensure the UI always receives a terminal event for proper state cleanup
+      if (!win.isDestroyed()) {
+        win.webContents.send(AGENT_EVENT, {
+          type: 'error',
+          message: err instanceof Error ? err.message : 'Unknown error',
+        });
+      }
+      throw err;
     }
   });
 

--- a/src/electron/main/coding-agent/handler.ts
+++ b/src/electron/main/coding-agent/handler.ts
@@ -48,14 +48,15 @@ export function registerCodingAgentHandlers(win: BrowserWindow): void {
         }
       }
     } catch (err) {
-      // Ensure the UI always receives a terminal event for proper state cleanup
+      // Send terminal error event so the UI can clean up state.
+      // Don't re-throw — the error event is the canonical error path,
+      // re-throwing would cause a duplicate AGENT_RUN_ERROR dispatch.
       if (!win.isDestroyed()) {
         win.webContents.send(AGENT_EVENT, {
           type: 'error',
           message: err instanceof Error ? err.message : 'Unknown error',
         });
       }
-      throw err;
     }
   });
 
@@ -80,6 +81,16 @@ export function registerCodingAgentHandlers(win: BrowserWindow): void {
     if (!adapter) throw new Error('Coding agent not started');
     await adapter.respondToUIRequest(response);
   });
+}
+
+/** Remove all coding agent IPC handlers (call from app before-quit) */
+export function unregisterCodingAgentHandlers(): void {
+  ipcMain.removeHandler(AGENT_START);
+  ipcMain.removeHandler(AGENT_EXECUTE);
+  ipcMain.removeHandler(AGENT_STEER);
+  ipcMain.removeHandler(AGENT_ABORT);
+  ipcMain.removeHandler(AGENT_STOP);
+  ipcMain.removeHandler(AGENT_UI_RESPONSE);
 }
 
 /** Gracefully stop the coding agent (call from app before-quit) */

--- a/src/electron/main/coding-agent/handler.ts
+++ b/src/electron/main/coding-agent/handler.ts
@@ -21,20 +21,29 @@ import {
 // NOTE: Module-level singleton — assumes a single BrowserWindow.
 // If multi-window support is added, this should become a Map<BrowserWindow, CodingAgentAdapter>.
 let adapter: CodingAgentAdapter | null = null;
+let starting = false;
 
 export function registerCodingAgentHandlers(win: BrowserWindow): void {
   ipcMain.handle(AGENT_START, async (_event, config: CodingAgentConfig) => {
-    // Reuse existing adapter if its process is alive and idle
-    if (adapter && adapter.isProcessAlive() && !adapter.isRunning()) {
-      return;
+    // Guard against concurrent start() calls — ipcMain.handle does NOT
+    // serialize async handlers, so two calls can interleave at await points.
+    if (starting) return;
+    starting = true;
+    try {
+      // Reuse existing adapter if its process is alive and idle
+      if (adapter && adapter.isProcessAlive() && !adapter.isRunning()) {
+        return;
+      }
+      // Stop any existing adapter before starting a new one
+      if (adapter) {
+        await adapter.stop();
+      }
+      adapter = createPiAdapter();
+      // Default cwd to main process working directory (renderer can't access process.cwd)
+      await adapter.start({ ...config, cwd: config.cwd || process.cwd() });
+    } finally {
+      starting = false;
     }
-    // Stop any existing adapter before starting a new one
-    if (adapter) {
-      await adapter.stop();
-    }
-    adapter = createPiAdapter();
-    // Default cwd to main process working directory (renderer can't access process.cwd)
-    await adapter.start({ ...config, cwd: config.cwd || process.cwd() });
   });
 
   ipcMain.handle(AGENT_EXECUTE, async (_event, task: string) => {

--- a/src/electron/main/coding-agent/handler.ts
+++ b/src/electron/main/coding-agent/handler.ts
@@ -18,6 +18,8 @@ import {
   AGENT_EVENT,
 } from '../../../shared/channels.js';
 
+// NOTE: Module-level singleton — assumes a single BrowserWindow.
+// If multi-window support is added, this should become a Map<BrowserWindow, CodingAgentAdapter>.
 let adapter: CodingAgentAdapter | null = null;
 
 export function registerCodingAgentHandlers(win: BrowserWindow): void {

--- a/src/electron/main/coding-agent/index.ts
+++ b/src/electron/main/coding-agent/index.ts
@@ -1,4 +1,4 @@
-export { registerCodingAgentHandlers, shutdownCodingAgent } from './handler.js';
+export { registerCodingAgentHandlers, unregisterCodingAgentHandlers, shutdownCodingAgent } from './handler.js';
 export type {
   CodingAgentAdapter,
   CodingAgentConfig,

--- a/src/electron/main/coding-agent/index.ts
+++ b/src/electron/main/coding-agent/index.ts
@@ -1,0 +1,8 @@
+export { registerCodingAgentHandlers, shutdownCodingAgent } from './handler.js';
+export type {
+  CodingAgentAdapter,
+  CodingAgentConfig,
+  AgentEvent,
+  AgentUsage,
+  ExtensionUIResponse,
+} from './adapter.js';

--- a/src/electron/main/coding-agent/pi-adapter.ts
+++ b/src/electron/main/coding-agent/pi-adapter.ts
@@ -49,6 +49,8 @@ export function createPiAdapter(): CodingAgentAdapter {
   let procExited = false;
   let bufferedFirstLine: string | null = null;
   let activeConfig: CodingAgentConfig | null = null;
+  // Shared abort signal: execute() sets this so abort() can terminate the generator
+  let abortCallback: (() => void) | null = null;
 
   function sendCommand(cmd: Record<string, unknown>): void {
     if (!proc?.stdin || !proc.stdin.writable) throw new Error('Pi process not available for commands');
@@ -210,6 +212,14 @@ export function createPiAdapter(): CodingAgentAdapter {
       rl.on('line', onLine);
       proc.on('close', onClose);
 
+      // Register abort callback so abort() can terminate the generator
+      abortCallback = () => {
+        if (!done) {
+          done = true;
+          resolve?.();
+        }
+      };
+
       // Replay the buffered first line from start() if it was a real event
       if (bufferedFirstLine) {
         onLine(bufferedFirstLine);
@@ -249,6 +259,7 @@ export function createPiAdapter(): CodingAgentAdapter {
         clearTimeout(execTimeout);
         rl.off('line', onLine);
         proc.off('close', onClose);
+        abortCallback = null;
       }
     },
 
@@ -262,6 +273,10 @@ export function createPiAdapter(): CodingAgentAdapter {
       if (procExited || !running) return; // No-op if already dead or idle
       sendCommand({ type: 'abort' });
       running = false;
+      // Terminate the execute() generator so it doesn't hang waiting
+      // for pi to send a terminal event or the execution timeout to fire.
+      abortCallback?.();
+      abortCallback = null;
     },
 
     async stop() {
@@ -302,6 +317,10 @@ export function createPiAdapter(): CodingAgentAdapter {
 
     async respondToUIRequest(response: ExtensionUIResponse) {
       sendCommand(response);
+    },
+
+    getActiveConfig() {
+      return activeConfig;
     },
   };
 }

--- a/src/electron/main/coding-agent/pi-adapter.ts
+++ b/src/electron/main/coding-agent/pi-adapter.ts
@@ -17,6 +17,23 @@ import type {
   ExtensionUIResponse,
 } from './adapter.js';
 
+/** Maximum task length in characters (100KB) */
+const MAX_TASK_LENGTH = 100_000;
+
+/** Allowlist of environment variable names the renderer may set */
+const ALLOWED_ENV_KEYS = new Set([
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'GOOGLE_API_KEY',
+  'MISTRAL_API_KEY',
+  'GROQ_API_KEY',
+  'OPENROUTER_API_KEY',
+  'TOGETHER_API_KEY',
+  'FIREWORKS_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'XAI_API_KEY',
+]);
+
 export function createPiAdapter(): CodingAgentAdapter {
   let proc: ChildProcess | null = null;
   let rl: readline.Interface | null = null;
@@ -35,9 +52,21 @@ export function createPiAdapter(): CodingAgentAdapter {
       if (config.model) args.push('--model', config.model);
       if (config.args) args.push(...config.args);
 
-      proc = spawn('node', [cliPath, ...args], {
+      // Filter env vars through allowlist to prevent the renderer from
+      // overriding sensitive variables like PATH or LD_PRELOAD.
+      const safeEnv: Record<string, string> = {};
+      if (config.env) {
+        for (const [key, val] of Object.entries(config.env)) {
+          if (ALLOWED_ENV_KEYS.has(key)) {
+            safeEnv[key] = val;
+          }
+        }
+      }
+
+      // Spawn pi directly (it may be a native binary or a Node shim on PATH)
+      proc = spawn(cliPath, args, {
         cwd: config.cwd,
-        env: { ...globalThis.process.env, ...config.env },
+        env: { ...globalThis.process.env, ...safeEnv },
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
@@ -52,28 +81,48 @@ export function createPiAdapter(): CodingAgentAdapter {
         }
       });
 
-      // Wait for process to be ready (or fail immediately)
+      // Wait for the first stdout line (pi ready signal) or process failure,
+      // with a generous fallback timeout instead of an arbitrary 500ms delay.
       await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => resolve(), 500);
-        proc!.on('error', (err) => {
-          clearTimeout(timeout);
+        const onReady = () => {
+          cleanup();
+          resolve();
+        };
+        const onError = (err: Error) => {
+          cleanup();
           reject(new Error(`Failed to start pi: ${err.message}`));
-        });
-        proc!.on('exit', (code) => {
+        };
+        const onExit = (code: number | null) => {
           if (code !== null && code !== 0) {
-            clearTimeout(timeout);
+            cleanup();
             reject(
               new Error(
                 `Pi process exited with code ${code}${stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''}`
               )
             );
           }
-        });
+        };
+        const cleanup = () => {
+          clearTimeout(timeout);
+          rl!.off('line', onReady);
+          proc!.off('error', onError);
+          proc!.off('exit', onExit);
+        };
+        // Generous fallback — if pi emits no stdout at all, eventually continue
+        const timeout = setTimeout(onReady, 5000);
+        rl!.once('line', onReady);
+        proc!.on('error', onError);
+        proc!.on('exit', onExit);
       });
     },
 
     async *execute(task: string): AsyncIterable<AgentEvent> {
       if (!proc?.stdin || !rl) throw new Error('Pi process not started');
+
+      if (task.length > MAX_TASK_LENGTH) {
+        throw new Error(`Task too long (${task.length} chars, max ${MAX_TASK_LENGTH})`);
+      }
+
       running = true;
 
       // Event queue with async signaling

--- a/src/electron/main/coding-agent/pi-adapter.ts
+++ b/src/electron/main/coding-agent/pi-adapter.ts
@@ -38,6 +38,7 @@ export function createPiAdapter(): CodingAgentAdapter {
   let proc: ChildProcess | null = null;
   let rl: readline.Interface | null = null;
   let running = false;
+  let procExited = false;
 
   function sendCommand(cmd: Record<string, unknown>): void {
     if (!proc?.stdin) throw new Error('Pi process not started');
@@ -50,7 +51,6 @@ export function createPiAdapter(): CodingAgentAdapter {
       const args = ['--mode', 'rpc'];
       if (config.provider) args.push('--provider', config.provider);
       if (config.model) args.push('--model', config.model);
-      if (config.args) args.push(...config.args);
 
       // Filter env vars through allowlist to prevent the renderer from
       // overriding sensitive variables like PATH or LD_PRELOAD.
@@ -71,6 +71,12 @@ export function createPiAdapter(): CodingAgentAdapter {
       });
 
       rl = readline.createInterface({ input: proc.stdout!, terminal: false });
+
+      // Track process exit so execute() can detect a dead process between calls
+      procExited = false;
+      proc.on('close', () => {
+        procExited = true;
+      });
 
       // Collect stderr for diagnostics (capped at 4KB to prevent unbounded growth)
       let stderrBuf = '';
@@ -109,7 +115,10 @@ export function createPiAdapter(): CodingAgentAdapter {
           proc!.off('exit', onExit);
         };
         // Generous fallback — if pi emits no stdout at all, eventually continue
-        const timeout = setTimeout(onReady, 5000);
+        const timeout = setTimeout(() => {
+          console.warn('[PiAdapter] pi did not emit a ready signal within 5s, proceeding optimistically');
+          onReady();
+        }, 5000);
         rl!.once('line', onReady);
         proc!.on('error', onError);
         proc!.on('exit', onExit);
@@ -118,6 +127,7 @@ export function createPiAdapter(): CodingAgentAdapter {
 
     async *execute(task: string): AsyncIterable<AgentEvent> {
       if (!proc?.stdin || !rl) throw new Error('Pi process not started');
+      if (procExited) throw new Error('Pi process has already exited');
 
       if (task.length > MAX_TASK_LENGTH) {
         throw new Error(`Task too long (${task.length} chars, max ${MAX_TASK_LENGTH})`);
@@ -211,6 +221,7 @@ export function createPiAdapter(): CodingAgentAdapter {
         proc = null;
         rl = null;
         running = false;
+        procExited = false;
       }
     },
 

--- a/src/electron/main/coding-agent/pi-adapter.ts
+++ b/src/electron/main/coding-agent/pi-adapter.ts
@@ -47,7 +47,9 @@ export function createPiAdapter(): CodingAgentAdapter {
 
   return {
     async start(config: CodingAgentConfig) {
-      const cliPath = config.cliPath ?? 'pi';
+      // Hardcode CLI path — ignore any renderer-supplied value to prevent
+      // arbitrary command execution from the untrusted renderer context.
+      const cliPath = 'pi';
       const args = ['--mode', 'rpc'];
       if (config.provider) args.push('--provider', config.provider);
       if (config.model) args.push('--model', config.model);
@@ -206,16 +208,19 @@ export function createPiAdapter(): CodingAgentAdapter {
       if (proc) {
         // Only attempt to kill if the process is still alive
         if (proc.exitCode === null && !proc.killed) {
-          proc.kill('SIGTERM');
+          const p = proc; // Capture reference before async gap
           await new Promise<void>((res) => {
-            const timeout = setTimeout(() => {
-              proc?.kill('SIGKILL');
-              res();
-            }, 2000);
-            proc?.on('exit', () => {
+            const onExit = () => {
               clearTimeout(timeout);
               res();
-            });
+            };
+            const timeout = setTimeout(() => {
+              p.off('exit', onExit);
+              p.kill('SIGKILL');
+              res();
+            }, 2000);
+            p.once('exit', onExit);
+            p.kill('SIGTERM');
           });
         }
         proc = null;

--- a/src/electron/main/coding-agent/pi-adapter.ts
+++ b/src/electron/main/coding-agent/pi-adapter.ts
@@ -43,10 +43,13 @@ export function createPiAdapter(): CodingAgentAdapter {
 
       rl = readline.createInterface({ input: proc.stdout!, terminal: false });
 
-      // Collect stderr for diagnostics
+      // Collect stderr for diagnostics (capped at 4KB to prevent unbounded growth)
       let stderrBuf = '';
       proc.stderr?.on('data', (chunk: Buffer) => {
         stderrBuf += chunk.toString();
+        if (stderrBuf.length > 4096) {
+          stderrBuf = stderrBuf.slice(-4096);
+        }
       });
 
       // Wait for process to be ready (or fail immediately)
@@ -142,17 +145,20 @@ export function createPiAdapter(): CodingAgentAdapter {
 
     async stop() {
       if (proc) {
-        proc.kill('SIGTERM');
-        await new Promise<void>((res) => {
-          const timeout = setTimeout(() => {
-            proc?.kill('SIGKILL');
-            res();
-          }, 2000);
-          proc?.on('exit', () => {
-            clearTimeout(timeout);
-            res();
+        // Only attempt to kill if the process is still alive
+        if (proc.exitCode === null && !proc.killed) {
+          proc.kill('SIGTERM');
+          await new Promise<void>((res) => {
+            const timeout = setTimeout(() => {
+              proc?.kill('SIGKILL');
+              res();
+            }, 2000);
+            proc?.on('exit', () => {
+              clearTimeout(timeout);
+              res();
+            });
           });
-        });
+        }
         proc = null;
         rl = null;
         running = false;

--- a/src/electron/main/coding-agent/pi-adapter.ts
+++ b/src/electron/main/coding-agent/pi-adapter.ts
@@ -39,9 +39,10 @@ export function createPiAdapter(): CodingAgentAdapter {
   let rl: readline.Interface | null = null;
   let running = false;
   let procExited = false;
+  let bufferedFirstLine: string | null = null;
 
   function sendCommand(cmd: Record<string, unknown>): void {
-    if (!proc?.stdin) throw new Error('Pi process not started');
+    if (!proc?.stdin || !proc.stdin.writable) throw new Error('Pi process not available for commands');
     proc.stdin.write(JSON.stringify(cmd) + '\n');
   }
 
@@ -90,9 +91,15 @@ export function createPiAdapter(): CodingAgentAdapter {
       });
 
       // Wait for the first stdout line (pi ready signal) or process failure,
-      // with a generous fallback timeout instead of an arbitrary 500ms delay.
+      // with a configurable fallback timeout.
+      const startTimeout = config.timeout ? Math.min(config.timeout, 30000) : 5000;
       await new Promise<void>((resolve, reject) => {
-        const onReady = () => {
+        const onReady = (line?: string) => {
+          // Buffer the first line so execute() can replay it — avoids
+          // silently dropping a real event if pi doesn't send a dedicated ready signal.
+          if (typeof line === 'string') {
+            bufferedFirstLine = line;
+          }
           cleanup();
           resolve();
         };
@@ -118,9 +125,9 @@ export function createPiAdapter(): CodingAgentAdapter {
         };
         // Generous fallback — if pi emits no stdout at all, eventually continue
         const timeout = setTimeout(() => {
-          console.warn('[PiAdapter] pi did not emit a ready signal within 5s, proceeding optimistically');
+          console.warn(`[PiAdapter] pi did not emit a ready signal within ${startTimeout / 1000}s, proceeding optimistically`);
           onReady();
-        }, 5000);
+        }, startTimeout);
         rl!.once('line', onReady);
         proc!.on('error', onError);
         proc!.on('exit', onExit);
@@ -130,6 +137,7 @@ export function createPiAdapter(): CodingAgentAdapter {
     async *execute(task: string): AsyncIterable<AgentEvent> {
       if (!proc?.stdin || !rl) throw new Error('Pi process not started');
       if (procExited) throw new Error('Pi process has already exited');
+      if (running) throw new Error('Already executing a task');
 
       if (task.length > MAX_TASK_LENGTH) {
         throw new Error(`Task too long (${task.length} chars, max ${MAX_TASK_LENGTH})`);
@@ -171,6 +179,12 @@ export function createPiAdapter(): CodingAgentAdapter {
       rl.on('line', onLine);
       proc.on('close', onClose);
 
+      // Replay the buffered first line from start() if it was a real event
+      if (bufferedFirstLine) {
+        onLine(bufferedFirstLine);
+        bufferedFirstLine = null;
+      }
+
       // Send prompt command
       sendCommand({ id: `exec_${Date.now()}`, type: 'prompt', message: task });
 
@@ -196,10 +210,12 @@ export function createPiAdapter(): CodingAgentAdapter {
     },
 
     async steer(message: string) {
+      if (procExited) throw new Error('Pi process has already exited');
       sendCommand({ type: 'steer', message });
     },
 
     async abort() {
+      if (procExited) return; // Silently no-op if already dead
       sendCommand({ type: 'abort' });
       running = false;
     },
@@ -227,11 +243,16 @@ export function createPiAdapter(): CodingAgentAdapter {
         rl = null;
         running = false;
         procExited = false;
+        bufferedFirstLine = null;
       }
     },
 
     isRunning() {
       return running;
+    },
+
+    isProcessAlive() {
+      return proc !== null && !procExited;
     },
 
     async respondToUIRequest(response: ExtensionUIResponse) {
@@ -257,7 +278,8 @@ export function createPiAdapter(): CodingAgentAdapter {
  * - extension_error
  */
 function translatePiEvent(raw: Record<string, unknown>): AgentEvent[] {
-  const type = raw.type as string;
+  const type = raw.type;
+  if (typeof type !== 'string') return [];
 
   switch (type) {
     case 'message_update': {
@@ -265,43 +287,67 @@ function translatePiEvent(raw: Record<string, unknown>): AgentEvent[] {
       if (!ame) return [];
       const ameType = ame.type as string;
       if (ameType === 'text_delta') {
-        return [{ type: 'text_delta', delta: ame.delta as string }];
+        const delta = ame.delta;
+        if (typeof delta !== 'string' || !delta) return [];
+        return [{ type: 'text_delta', delta }];
       }
       if (ameType === 'thinking_delta') {
-        return [{ type: 'thinking_delta', delta: ame.delta as string }];
+        const delta = ame.delta;
+        if (typeof delta !== 'string' || !delta) return [];
+        return [{ type: 'thinking_delta', delta }];
       }
       return [];
     }
 
-    case 'tool_execution_start':
+    case 'tool_execution_start': {
+      const toolCallId = raw.toolCallId;
+      const toolName = raw.toolName;
+      if (typeof toolCallId !== 'string' || typeof toolName !== 'string') {
+        console.warn('[PiAdapter] Malformed tool_execution_start event:', raw);
+        return [];
+      }
       return [
         {
           type: 'tool_start',
-          toolCallId: raw.toolCallId as string,
-          toolName: raw.toolName as string,
+          toolCallId,
+          toolName,
           args: (raw.args as Record<string, unknown>) ?? {},
         },
       ];
+    }
 
-    case 'tool_execution_update':
+    case 'tool_execution_update': {
+      const toolCallId = raw.toolCallId;
+      if (typeof toolCallId !== 'string') {
+        console.warn('[PiAdapter] Malformed tool_execution_update event:', raw);
+        return [];
+      }
       return [
         {
           type: 'tool_update',
-          toolCallId: raw.toolCallId as string,
+          toolCallId,
           partialResult: raw.partialResult,
         },
       ];
+    }
 
-    case 'tool_execution_end':
+    case 'tool_execution_end': {
+      const toolCallId = raw.toolCallId;
+      const toolName = raw.toolName;
+      if (typeof toolCallId !== 'string' || typeof toolName !== 'string') {
+        console.warn('[PiAdapter] Malformed tool_execution_end event:', raw);
+        return [];
+      }
       return [
         {
           type: 'tool_end',
-          toolCallId: raw.toolCallId as string,
-          toolName: raw.toolName as string,
+          toolCallId,
+          toolName,
           result: raw.result,
           isError: (raw.isError as boolean) ?? false,
         },
       ];
+    }
 
     case 'auto_compaction_start': {
       const reason = raw.reason as string;

--- a/src/electron/main/coding-agent/pi-adapter.ts
+++ b/src/electron/main/coding-agent/pi-adapter.ts
@@ -9,6 +9,8 @@
  */
 
 import { ChildProcess, spawn } from 'node:child_process';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
 import * as readline from 'node:readline';
 import type {
   CodingAgentAdapter,
@@ -19,6 +21,9 @@ import type {
 
 /** Maximum task length in characters (100KB) */
 const MAX_TASK_LENGTH = 100_000;
+
+/** Default execution timeout: 30 minutes */
+const DEFAULT_EXECUTION_TIMEOUT_MS = 30 * 60 * 1000;
 
 /** Pattern for validating CLI argument values (provider, model) */
 const SAFE_ARG_PATTERN = /^[a-zA-Z0-9._:/-]{1,128}$/;
@@ -43,6 +48,7 @@ export function createPiAdapter(): CodingAgentAdapter {
   let running = false;
   let procExited = false;
   let bufferedFirstLine: string | null = null;
+  let activeConfig: CodingAgentConfig | null = null;
 
   function sendCommand(cmd: Record<string, unknown>): void {
     if (!proc?.stdin || !proc.stdin.writable) throw new Error('Pi process not available for commands');
@@ -76,9 +82,22 @@ export function createPiAdapter(): CodingAgentAdapter {
         }
       }
 
+      // Validate cwd — must be an absolute, accessible directory
+      const cwd = config.cwd;
+      if (cwd) {
+        if (!path.isAbsolute(cwd)) throw new Error('cwd must be an absolute path');
+        try {
+          fs.accessSync(cwd, fs.constants.R_OK);
+        } catch {
+          throw new Error(`cwd is not accessible: ${cwd}`);
+        }
+      }
+
+      activeConfig = config;
+
       // Spawn pi directly (it may be a native binary or a Node shim on PATH)
       proc = spawn(cliPath, args, {
-        cwd: config.cwd,
+        cwd,
         env: { ...globalThis.process.env, ...safeEnv },
         stdio: ['pipe', 'pipe', 'pipe'],
       });
@@ -200,6 +219,17 @@ export function createPiAdapter(): CodingAgentAdapter {
       // Send prompt command
       sendCommand({ id: `exec_${Date.now()}`, type: 'prompt', message: task });
 
+      // Execution timeout — prevents the UI from hanging forever if pi
+      // neither completes nor crashes.
+      const execTimeout = setTimeout(() => {
+        if (!done) {
+          queue.push({ type: 'error', message: 'Agent execution timed out' });
+          done = true;
+          running = false;
+          resolve?.();
+        }
+      }, activeConfig?.executionTimeout ?? DEFAULT_EXECUTION_TIMEOUT_MS);
+
       try {
         while (!done) {
           if (queue.length > 0) {
@@ -216,6 +246,7 @@ export function createPiAdapter(): CodingAgentAdapter {
           yield queue.shift()!;
         }
       } finally {
+        clearTimeout(execTimeout);
         rl.off('line', onLine);
         proc.off('close', onClose);
       }
@@ -223,11 +254,12 @@ export function createPiAdapter(): CodingAgentAdapter {
 
     async steer(message: string) {
       if (procExited) throw new Error('Pi process has already exited');
+      if (!running) throw new Error('No task is currently running');
       sendCommand({ type: 'steer', message });
     },
 
     async abort() {
-      if (procExited) return; // Silently no-op if already dead
+      if (procExited || !running) return; // No-op if already dead or idle
       sendCommand({ type: 'abort' });
       running = false;
     },
@@ -256,6 +288,7 @@ export function createPiAdapter(): CodingAgentAdapter {
         running = false;
         procExited = false;
         bufferedFirstLine = null;
+        activeConfig = null;
       }
     },
 
@@ -362,7 +395,7 @@ function translatePiEvent(raw: Record<string, unknown>): AgentEvent[] {
     }
 
     case 'auto_compaction_start': {
-      const reason = raw.reason as string;
+      const reason = typeof raw.reason === 'string' ? raw.reason : 'unknown';
       const msg =
         reason === 'overflow'
           ? 'Context overflow \u2014 compacting...'
@@ -371,9 +404,9 @@ function translatePiEvent(raw: Record<string, unknown>): AgentEvent[] {
     }
 
     case 'auto_compaction_end': {
-      const aborted = raw.aborted as boolean;
-      const willRetry = raw.willRetry as boolean;
-      const errorMessage = raw.errorMessage as string | undefined;
+      const aborted = typeof raw.aborted === 'boolean' ? raw.aborted : false;
+      const willRetry = typeof raw.willRetry === 'boolean' ? raw.willRetry : false;
+      const errorMessage = typeof raw.errorMessage === 'string' ? raw.errorMessage : undefined;
 
       let msg: string;
       if (aborted && willRetry) {
@@ -387,19 +420,19 @@ function translatePiEvent(raw: Record<string, unknown>): AgentEvent[] {
     }
 
     case 'auto_retry_start': {
-      const attempt = raw.attempt as number;
-      const maxAttempts = raw.maxAttempts as number;
-      const delayMs = raw.delayMs as number;
-      const errorMessage = raw.errorMessage as string;
+      const attempt = typeof raw.attempt === 'number' ? raw.attempt : 0;
+      const maxAttempts = typeof raw.maxAttempts === 'number' ? raw.maxAttempts : 0;
+      const delayMs = typeof raw.delayMs === 'number' ? raw.delayMs : 0;
+      const errorMessage = typeof raw.errorMessage === 'string' ? raw.errorMessage : 'Unknown error';
       const delaySec = Math.round(delayMs / 1000);
       const msg = `Retrying (${attempt}/${maxAttempts}) in ${delaySec}s: ${errorMessage}`;
       return [{ type: 'status', message: msg, detail: { attempt, maxAttempts, delayMs, errorMessage } }];
     }
 
     case 'auto_retry_end': {
-      const success = raw.success as boolean;
-      const attempt = raw.attempt as number;
-      const finalError = raw.finalError as string | undefined;
+      const success = typeof raw.success === 'boolean' ? raw.success : false;
+      const attempt = typeof raw.attempt === 'number' ? raw.attempt : 0;
+      const finalError = typeof raw.finalError === 'string' ? raw.finalError : undefined;
       if (!success && finalError) {
         return [{ type: 'status', message: `Retry failed after ${attempt} attempts: ${finalError}` }];
       }
@@ -458,13 +491,18 @@ function translatePiEvent(raw: Record<string, unknown>): AgentEvent[] {
         return [{ type: 'status', message: msg }];
       }
 
-      // Interactive methods (select, confirm, input, editor) require host response
+      // Interactive methods (select, confirm, input, editor) require host response.
+      // Explicitly pick expected fields — avoid spreading raw subprocess data into IPC.
       return [
         {
-          type: 'ui_request',
+          type: 'ui_request' as const,
           id: raw.id as string,
           method,
-          ...(raw as Record<string, unknown>),
+          message: typeof raw.message === 'string' ? raw.message : undefined,
+          options: Array.isArray(raw.options) ? raw.options : undefined,
+          title: typeof raw.title === 'string' ? raw.title : undefined,
+          placeholder: typeof raw.placeholder === 'string' ? raw.placeholder : undefined,
+          defaultValue: typeof raw.defaultValue === 'string' ? raw.defaultValue : undefined,
         },
       ];
     }

--- a/src/electron/main/coding-agent/pi-adapter.ts
+++ b/src/electron/main/coding-agent/pi-adapter.ts
@@ -20,6 +20,9 @@ import type {
 /** Maximum task length in characters (100KB) */
 const MAX_TASK_LENGTH = 100_000;
 
+/** Pattern for validating CLI argument values (provider, model) */
+const SAFE_ARG_PATTERN = /^[a-zA-Z0-9._:/-]{1,128}$/;
+
 /** Allowlist of environment variable names the renderer may set */
 const ALLOWED_ENV_KEYS = new Set([
   'ANTHROPIC_API_KEY',
@@ -43,6 +46,7 @@ export function createPiAdapter(): CodingAgentAdapter {
 
   function sendCommand(cmd: Record<string, unknown>): void {
     if (!proc?.stdin || !proc.stdin.writable) throw new Error('Pi process not available for commands');
+    // Fire-and-forget: commands are small (<1KB) and infrequent, so backpressure is not expected.
     proc.stdin.write(JSON.stringify(cmd) + '\n');
   }
 
@@ -52,8 +56,14 @@ export function createPiAdapter(): CodingAgentAdapter {
       // arbitrary command execution from the untrusted renderer context.
       const cliPath = 'pi';
       const args = ['--mode', 'rpc'];
-      if (config.provider) args.push('--provider', config.provider);
-      if (config.model) args.push('--model', config.model);
+      if (config.provider) {
+        if (!SAFE_ARG_PATTERN.test(config.provider)) throw new Error('Invalid provider name');
+        args.push('--provider', config.provider);
+      }
+      if (config.model) {
+        if (!SAFE_ARG_PATTERN.test(config.model)) throw new Error('Invalid model name');
+        args.push('--model', config.model);
+      }
 
       // Filter env vars through allowlist to prevent the renderer from
       // overriding sensitive variables like PATH or LD_PRELOAD.
@@ -108,13 +118,15 @@ export function createPiAdapter(): CodingAgentAdapter {
           reject(new Error(`Failed to start pi: ${err.message}`));
         };
         const onExit = (code: number | null) => {
+          cleanup();
           if (code !== null && code !== 0) {
-            cleanup();
             reject(
               new Error(
                 `Pi process exited with code ${code}${stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''}`
               )
             );
+          } else if (code === 0) {
+            reject(new Error('Pi process exited immediately (code 0) without producing output'));
           }
         };
         const cleanup = () => {

--- a/src/electron/main/coding-agent/pi-adapter.ts
+++ b/src/electron/main/coding-agent/pi-adapter.ts
@@ -1,0 +1,355 @@
+/**
+ * Pi Coding Agent Adapter
+ *
+ * Spawns the pi CLI as a subprocess in RPC mode (--mode rpc)
+ * and communicates via JSONL over stdin/stdout.
+ *
+ * Event translation maps pi's native event shapes to the
+ * normalized AgentEvent type used by the rest of the app.
+ */
+
+import { ChildProcess, spawn } from 'node:child_process';
+import * as readline from 'node:readline';
+import type {
+  CodingAgentAdapter,
+  CodingAgentConfig,
+  AgentEvent,
+  ExtensionUIResponse,
+} from './adapter.js';
+
+export function createPiAdapter(): CodingAgentAdapter {
+  let proc: ChildProcess | null = null;
+  let rl: readline.Interface | null = null;
+  let running = false;
+
+  function sendCommand(cmd: Record<string, unknown>): void {
+    if (!proc?.stdin) throw new Error('Pi process not started');
+    proc.stdin.write(JSON.stringify(cmd) + '\n');
+  }
+
+  return {
+    async start(config: CodingAgentConfig) {
+      const cliPath = config.cliPath ?? 'pi';
+      const args = ['--mode', 'rpc'];
+      if (config.provider) args.push('--provider', config.provider);
+      if (config.model) args.push('--model', config.model);
+      if (config.args) args.push(...config.args);
+
+      proc = spawn('node', [cliPath, ...args], {
+        cwd: config.cwd,
+        env: { ...globalThis.process.env, ...config.env },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      rl = readline.createInterface({ input: proc.stdout!, terminal: false });
+
+      // Collect stderr for diagnostics
+      let stderrBuf = '';
+      proc.stderr?.on('data', (chunk: Buffer) => {
+        stderrBuf += chunk.toString();
+      });
+
+      // Wait for process to be ready (or fail immediately)
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => resolve(), 500);
+        proc!.on('error', (err) => {
+          clearTimeout(timeout);
+          reject(new Error(`Failed to start pi: ${err.message}`));
+        });
+        proc!.on('exit', (code) => {
+          if (code !== null && code !== 0) {
+            clearTimeout(timeout);
+            reject(
+              new Error(
+                `Pi process exited with code ${code}${stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''}`
+              )
+            );
+          }
+        });
+      });
+    },
+
+    async *execute(task: string): AsyncIterable<AgentEvent> {
+      if (!proc?.stdin || !rl) throw new Error('Pi process not started');
+      running = true;
+
+      // Event queue with async signaling
+      const queue: AgentEvent[] = [];
+      let resolve: (() => void) | null = null;
+      let done = false;
+
+      const onLine = (line: string) => {
+        try {
+          const data = JSON.parse(line);
+          const events = translatePiEvent(data);
+          for (const event of events) {
+            queue.push(event);
+            if (event.type === 'complete' || event.type === 'error') {
+              done = true;
+              running = false;
+            }
+          }
+          resolve?.();
+        } catch {
+          // Ignore non-JSON lines (stderr leaks, blank lines, etc.)
+        }
+      };
+
+      const onClose = () => {
+        if (!done) {
+          queue.push({ type: 'error', message: 'Pi process exited unexpectedly' });
+          done = true;
+          running = false;
+          resolve?.();
+        }
+      };
+
+      rl.on('line', onLine);
+      proc.on('close', onClose);
+
+      // Send prompt command
+      sendCommand({ id: `exec_${Date.now()}`, type: 'prompt', message: task });
+
+      try {
+        while (!done) {
+          if (queue.length > 0) {
+            yield queue.shift()!;
+          } else {
+            await new Promise<void>((r) => {
+              resolve = r;
+            });
+            resolve = null;
+          }
+        }
+        // Drain remaining events
+        while (queue.length > 0) {
+          yield queue.shift()!;
+        }
+      } finally {
+        rl.off('line', onLine);
+        proc.off('close', onClose);
+      }
+    },
+
+    async steer(message: string) {
+      sendCommand({ type: 'steer', message });
+    },
+
+    async abort() {
+      sendCommand({ type: 'abort' });
+      running = false;
+    },
+
+    async stop() {
+      if (proc) {
+        proc.kill('SIGTERM');
+        await new Promise<void>((res) => {
+          const timeout = setTimeout(() => {
+            proc?.kill('SIGKILL');
+            res();
+          }, 2000);
+          proc?.on('exit', () => {
+            clearTimeout(timeout);
+            res();
+          });
+        });
+        proc = null;
+        rl = null;
+        running = false;
+      }
+    },
+
+    isRunning() {
+      return running;
+    },
+
+    async respondToUIRequest(response: ExtensionUIResponse) {
+      sendCommand(response);
+    },
+  };
+}
+
+// ============================================
+// Event Translation
+// ============================================
+
+/**
+ * Translate a raw pi RPC event into normalized AgentEvent(s).
+ *
+ * Pi event types (from rpc-types.ts):
+ * - message_update (with assistantMessageEvent: text_delta | thinking_delta | ...)
+ * - tool_execution_start/update/end
+ * - auto_compaction_start/end
+ * - auto_retry_start/end
+ * - agent_end
+ * - extension_ui_request (select, confirm, input, editor, notify, setStatus, setWidget, setTitle, set_editor_text)
+ * - extension_error
+ */
+function translatePiEvent(raw: Record<string, unknown>): AgentEvent[] {
+  const type = raw.type as string;
+
+  switch (type) {
+    case 'message_update': {
+      const ame = raw.assistantMessageEvent as Record<string, unknown> | undefined;
+      if (!ame) return [];
+      const ameType = ame.type as string;
+      if (ameType === 'text_delta') {
+        return [{ type: 'text_delta', delta: ame.delta as string }];
+      }
+      if (ameType === 'thinking_delta') {
+        return [{ type: 'thinking_delta', delta: ame.delta as string }];
+      }
+      return [];
+    }
+
+    case 'tool_execution_start':
+      return [
+        {
+          type: 'tool_start',
+          toolCallId: raw.toolCallId as string,
+          toolName: raw.toolName as string,
+          args: (raw.args as Record<string, unknown>) ?? {},
+        },
+      ];
+
+    case 'tool_execution_update':
+      return [
+        {
+          type: 'tool_update',
+          toolCallId: raw.toolCallId as string,
+          partialResult: raw.partialResult,
+        },
+      ];
+
+    case 'tool_execution_end':
+      return [
+        {
+          type: 'tool_end',
+          toolCallId: raw.toolCallId as string,
+          toolName: raw.toolName as string,
+          result: raw.result,
+          isError: (raw.isError as boolean) ?? false,
+        },
+      ];
+
+    case 'auto_compaction_start': {
+      const reason = raw.reason as string;
+      const msg =
+        reason === 'overflow'
+          ? 'Context overflow \u2014 compacting...'
+          : 'Compacting context...';
+      return [{ type: 'status', message: msg, detail: { reason } }];
+    }
+
+    case 'auto_compaction_end': {
+      const aborted = raw.aborted as boolean;
+      const willRetry = raw.willRetry as boolean;
+      const errorMessage = raw.errorMessage as string | undefined;
+
+      let msg: string;
+      if (aborted && willRetry) {
+        msg = 'Compaction interrupted, retrying...';
+      } else if (aborted || errorMessage) {
+        msg = errorMessage ? `Compaction failed: ${errorMessage}` : 'Compaction failed';
+      } else {
+        msg = 'Context compacted';
+      }
+      return [{ type: 'status', message: msg, detail: { aborted, willRetry, errorMessage } }];
+    }
+
+    case 'auto_retry_start': {
+      const attempt = raw.attempt as number;
+      const maxAttempts = raw.maxAttempts as number;
+      const delayMs = raw.delayMs as number;
+      const errorMessage = raw.errorMessage as string;
+      const delaySec = Math.round(delayMs / 1000);
+      const msg = `Retrying (${attempt}/${maxAttempts}) in ${delaySec}s: ${errorMessage}`;
+      return [{ type: 'status', message: msg, detail: { attempt, maxAttempts, delayMs, errorMessage } }];
+    }
+
+    case 'auto_retry_end': {
+      const success = raw.success as boolean;
+      const attempt = raw.attempt as number;
+      const finalError = raw.finalError as string | undefined;
+      if (!success && finalError) {
+        return [{ type: 'status', message: `Retry failed after ${attempt} attempts: ${finalError}` }];
+      }
+      // On success, no status needed — normal events resume
+      return [];
+    }
+
+    case 'agent_end': {
+      const usage = raw.usage as Record<string, unknown> | undefined;
+      return [
+        {
+          type: 'complete',
+          usage: usage
+            ? {
+                inputTokens: (usage.inputTokens as number) ?? 0,
+                outputTokens: (usage.outputTokens as number) ?? 0,
+                totalCost: (usage.totalCost as number) ?? 0,
+              }
+            : undefined,
+        },
+      ];
+    }
+
+    case 'extension_ui_request': {
+      const method = raw.method as string;
+
+      // Map new extension methods to dedicated event types
+      if (method === 'setStatus') {
+        return [
+          {
+            type: 'set_status',
+            statusKey: raw.statusKey as string,
+            statusText: raw.statusText as string | undefined,
+          },
+        ];
+      }
+      if (method === 'setWidget') {
+        return [
+          {
+            type: 'set_widget',
+            widgetKey: raw.widgetKey as string,
+            widgetLines: raw.widgetLines as string[] | undefined,
+            widgetPlacement: raw.widgetPlacement as string | undefined,
+          },
+        ];
+      }
+      if (method === 'setTitle') {
+        return [{ type: 'set_title', title: raw.title as string }];
+      }
+      if (method === 'set_editor_text') {
+        // Treat as a text update for now
+        return [];
+      }
+      if (method === 'notify') {
+        const msg = raw.message as string;
+        return [{ type: 'status', message: msg }];
+      }
+
+      // Interactive methods (select, confirm, input, editor) require host response
+      return [
+        {
+          type: 'ui_request',
+          id: raw.id as string,
+          method,
+          ...(raw as Record<string, unknown>),
+        },
+      ];
+    }
+
+    case 'extension_error': {
+      const extPath = raw.extensionPath as string;
+      const event = raw.event as string;
+      const error = raw.error as string;
+      return [
+        { type: 'status', message: `Extension error (${extPath}/${event}): ${error}` },
+      ];
+    }
+
+    default:
+      return [];
+  }
+}

--- a/src/electron/main/index.ts
+++ b/src/electron/main/index.ts
@@ -13,7 +13,7 @@ import * as path from 'node:path';
 import log from 'electron-log';
 import { setupIPCHandlers, cleanupIPCHandlers } from './ipc-handlers.js';
 import { McpManager } from './mcp-manager.js';
-import { registerCodingAgentHandlers, shutdownCodingAgent } from './coding-agent/index.js';
+import { registerCodingAgentHandlers, unregisterCodingAgentHandlers, shutdownCodingAgent } from './coding-agent/index.js';
 
 // Configure logging
 log.transports.file.level = 'info';
@@ -124,6 +124,7 @@ const quitHandler = (e: Electron.Event) => {
   e.preventDefault();
   log.info('Application quitting, cleaning up...');
   cleanupIPCHandlers();
+  unregisterCodingAgentHandlers();
   Promise.all([
     shutdownCodingAgent(),
     serverManager ? serverManager.shutdown() : Promise.resolve(),

--- a/src/electron/main/index.ts
+++ b/src/electron/main/index.ts
@@ -116,15 +116,22 @@ app.on('window-all-closed', () => {
   }
 });
 
-// Clean up before quit
-app.on('before-quit', async () => {
+// Clean up before quit — use preventDefault to ensure async cleanup completes
+app.on('before-quit', (e) => {
+  e.preventDefault();
   log.info('Application quitting, cleaning up...');
   cleanupIPCHandlers();
-  await shutdownCodingAgent();
-  if (serverManager) {
-    await serverManager.shutdown();
-    serverManager = null;
-  }
+  Promise.all([
+    shutdownCodingAgent(),
+    serverManager ? serverManager.shutdown() : Promise.resolve(),
+  ])
+    .catch((err) => log.error('Cleanup error:', err))
+    .finally(() => {
+      serverManager = null;
+      // Remove this handler to avoid infinite loop, then quit
+      app.removeAllListeners('before-quit');
+      app.quit();
+    });
 });
 
 // Handle uncaught exceptions

--- a/src/electron/main/index.ts
+++ b/src/electron/main/index.ts
@@ -117,7 +117,10 @@ app.on('window-all-closed', () => {
 });
 
 // Clean up before quit — use preventDefault to ensure async cleanup completes
-app.on('before-quit', (e) => {
+let isQuitting = false;
+const quitHandler = (e: Electron.Event) => {
+  if (isQuitting) return;
+  isQuitting = true;
   e.preventDefault();
   log.info('Application quitting, cleaning up...');
   cleanupIPCHandlers();
@@ -128,11 +131,11 @@ app.on('before-quit', (e) => {
     .catch((err) => log.error('Cleanup error:', err))
     .finally(() => {
       serverManager = null;
-      // Remove this handler to avoid infinite loop, then quit
-      app.removeAllListeners('before-quit');
+      app.removeListener('before-quit', quitHandler);
       app.quit();
     });
-});
+};
+app.on('before-quit', quitHandler);
 
 // Handle uncaught exceptions
 process.on('uncaughtException', (error) => {

--- a/src/electron/main/index.ts
+++ b/src/electron/main/index.ts
@@ -13,6 +13,7 @@ import * as path from 'node:path';
 import log from 'electron-log';
 import { setupIPCHandlers, cleanupIPCHandlers } from './ipc-handlers.js';
 import { McpManager } from './mcp-manager.js';
+import { registerCodingAgentHandlers, shutdownCodingAgent } from './coding-agent/index.js';
 
 // Configure logging
 log.transports.file.level = 'info';
@@ -54,6 +55,9 @@ const createWindow = async (): Promise<void> => {
 
   // Setup IPC handlers with server manager
   setupIPCHandlers(mainWindow, serverManager);
+
+  // Setup coding agent IPC handlers
+  registerCodingAgentHandlers(mainWindow);
 
   // Load the app
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
@@ -116,6 +120,7 @@ app.on('window-all-closed', () => {
 app.on('before-quit', async () => {
   log.info('Application quitting, cleaning up...');
   cleanupIPCHandlers();
+  await shutdownCodingAgent();
   if (serverManager) {
     await serverManager.shutdown();
     serverManager = null;

--- a/src/electron/preload/host.ts
+++ b/src/electron/preload/host.ts
@@ -387,6 +387,53 @@ const electronAPI = {
       ipcRenderer.removeListener(channels.ON_MANAGER_READY, handler);
     };
   },
+
+  // ============================================
+  // Coding Agent
+  // ============================================
+
+  codingAgent: {
+    start: (config: { cwd: string; provider?: string; model?: string; cliPath?: string; env?: Record<string, string> }) => {
+      validateInvokeChannel(channels.AGENT_START);
+      return ipcRenderer.invoke(channels.AGENT_START, config);
+    },
+
+    execute: (task: string) => {
+      validateInvokeChannel(channels.AGENT_EXECUTE);
+      return ipcRenderer.invoke(channels.AGENT_EXECUTE, task);
+    },
+
+    steer: (message: string) => {
+      validateInvokeChannel(channels.AGENT_STEER);
+      return ipcRenderer.invoke(channels.AGENT_STEER, message);
+    },
+
+    abort: () => {
+      validateInvokeChannel(channels.AGENT_ABORT);
+      return ipcRenderer.invoke(channels.AGENT_ABORT);
+    },
+
+    stop: () => {
+      validateInvokeChannel(channels.AGENT_STOP);
+      return ipcRenderer.invoke(channels.AGENT_STOP);
+    },
+
+    respondToUIRequest: (response: { type: string; id: string; [key: string]: unknown }) => {
+      validateInvokeChannel(channels.AGENT_UI_RESPONSE);
+      return ipcRenderer.invoke(channels.AGENT_UI_RESPONSE, response);
+    },
+
+    onEvent: (callback: (event: Record<string, unknown>) => void): (() => void) => {
+      validateOnChannel(channels.AGENT_EVENT);
+      const handler = (_event: Electron.IpcRendererEvent, data: Record<string, unknown>) => {
+        callback(data);
+      };
+      ipcRenderer.on(channels.AGENT_EVENT, handler);
+      return () => {
+        ipcRenderer.removeListener(channels.AGENT_EVENT, handler);
+      };
+    },
+  },
 };
 
 // ============================================

--- a/src/electron/preload/host.ts
+++ b/src/electron/preload/host.ts
@@ -418,7 +418,7 @@ const electronAPI = {
       return ipcRenderer.invoke(channels.AGENT_STOP);
     },
 
-    respondToUIRequest: (response: { type: string; id: string; [key: string]: unknown }) => {
+    respondToUIRequest: (response: { type: 'extension_ui_response'; id: string; [key: string]: unknown }) => {
       validateInvokeChannel(channels.AGENT_UI_RESPONSE);
       return ipcRenderer.invoke(channels.AGENT_UI_RESPONSE, response);
     },

--- a/src/electron/preload/host.ts
+++ b/src/electron/preload/host.ts
@@ -393,7 +393,7 @@ const electronAPI = {
   // ============================================
 
   codingAgent: {
-    start: (config: { cwd: string; provider?: string; model?: string; cliPath?: string; env?: Record<string, string> }) => {
+    start: (config: { cwd?: string; provider?: string; model?: string; cliPath?: string; env?: Record<string, string> }) => {
       validateInvokeChannel(channels.AGENT_START);
       return ipcRenderer.invoke(channels.AGENT_START, config);
     },

--- a/src/renderer/chat/components/AgentRunBlock.tsx
+++ b/src/renderer/chat/components/AgentRunBlock.tsx
@@ -77,8 +77,11 @@ export function AgentRunBlock({ message, onSteer, onAbort }: AgentRunBlockProps)
 
       {/* Interleaved blocks */}
       <div className="agent-run-blocks">
-        {message.blocks.map((block, i) => (
-          <AgentBlockRenderer key={i} block={block} />
+        {message.blocks.map((block) => (
+          <AgentBlockRenderer
+            key={block.type === 'tool' ? block.toolCallId : block.id}
+            block={block}
+          />
         ))}
       </div>
 

--- a/src/renderer/chat/components/AgentRunBlock.tsx
+++ b/src/renderer/chat/components/AgentRunBlock.tsx
@@ -5,7 +5,7 @@
  * (text, tool calls, thinking, status) produced by the coding agent.
  */
 
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import type { AgentRunMessage, AgentBlock, AgentToolBlock as AgentToolBlockType } from '../types';
 
 /** Max characters to show for tool results before truncating */
@@ -111,7 +111,7 @@ export function AgentRunBlock({ message, onSteer, onAbort }: AgentRunBlockProps)
 // Block Renderer
 // ============================================
 
-function AgentBlockRenderer({ block }: { block: AgentBlock }) {
+const AgentBlockRenderer = memo(function AgentBlockRenderer({ block }: { block: AgentBlock }) {
   switch (block.type) {
     case 'text':
       return <div className="agent-block-text">{block.content}</div>;
@@ -125,7 +125,7 @@ function AgentBlockRenderer({ block }: { block: AgentBlock }) {
     case 'status':
       return <div className="agent-block-status">{block.message}</div>;
   }
-}
+});
 
 // ============================================
 // Thinking Block (collapsible)

--- a/src/renderer/chat/components/AgentRunBlock.tsx
+++ b/src/renderer/chat/components/AgentRunBlock.tsx
@@ -1,0 +1,286 @@
+/**
+ * Agent Run Block Component
+ *
+ * Renders an AgentRunMessage in the chat — a container of ordered blocks
+ * (text, tool calls, thinking, status) produced by the coding agent.
+ */
+
+import { useState } from 'react';
+import type { AgentRunMessage, AgentBlock, AgentToolBlock as AgentToolBlockType } from '../types';
+
+// ============================================
+// Known tool display metadata
+// ============================================
+
+const KNOWN_TOOLS: Record<string, { label: string }> = {
+  bash: { label: 'Shell' },
+  read: { label: 'Read File' },
+  edit: { label: 'Edit File' },
+  write: { label: 'Write File' },
+  grep: { label: 'Search' },
+  find: { label: 'Find Files' },
+  ls: { label: 'List Directory' },
+};
+
+// ============================================
+// Main Component
+// ============================================
+
+interface AgentRunBlockProps {
+  message: AgentRunMessage;
+  onSteer?: (message: string) => void;
+  onAbort?: () => void;
+}
+
+export function AgentRunBlock({ message, onSteer, onAbort }: AgentRunBlockProps) {
+  return (
+    <div className="agent-run-block" data-status={message.status}>
+      {/* Header */}
+      <div className="agent-run-header">
+        <span className="agent-run-icon">
+          {message.status === 'running' ? (
+            <span className="agent-spinner" />
+          ) : message.status === 'completed' ? (
+            '\u2713'
+          ) : (
+            '\u2717'
+          )}
+        </span>
+        <span className="agent-run-title">
+          {message.title || 'Coding Agent'}
+        </span>
+        {message.model && (
+          <span className="agent-run-model">
+            {message.model.provider}/{message.model.id}
+          </span>
+        )}
+        {message.status === 'running' && onAbort && (
+          <button className="agent-abort-btn" onClick={onAbort}>
+            Abort
+          </button>
+        )}
+      </div>
+
+      {/* Task description */}
+      <div className="agent-run-task">{message.task}</div>
+
+      {/* Extension statuses */}
+      {Object.entries(message.statuses).length > 0 && (
+        <div className="agent-run-statuses">
+          {Object.entries(message.statuses).map(([key, text]) => (
+            <span key={key} className="agent-status-badge">
+              {text}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Interleaved blocks */}
+      <div className="agent-run-blocks">
+        {message.blocks.map((block, i) => (
+          <AgentBlockRenderer key={i} block={block} />
+        ))}
+      </div>
+
+      {/* Footer: usage stats when complete */}
+      {message.status === 'completed' && message.usage && (
+        <div className="agent-run-footer">
+          {message.usage.inputTokens + message.usage.outputTokens} tokens | $
+          {message.usage.totalCost.toFixed(4)}
+        </div>
+      )}
+
+      {/* Steer input (only while running) */}
+      {message.status === 'running' && onSteer && <SteerInput onSubmit={onSteer} />}
+
+      {/* Error display */}
+      {message.status === 'error' && message.error && (
+        <div className="agent-run-error">{message.error}</div>
+      )}
+    </div>
+  );
+}
+
+// ============================================
+// Block Renderer
+// ============================================
+
+function AgentBlockRenderer({ block }: { block: AgentBlock }) {
+  switch (block.type) {
+    case 'text':
+      return <div className="agent-block-text">{block.content}</div>;
+
+    case 'thinking':
+      return <AgentThinkingBlock content={block.content} />;
+
+    case 'tool':
+      return <AgentToolView block={block} />;
+
+    case 'status':
+      return <div className="agent-block-status">{block.message}</div>;
+  }
+}
+
+// ============================================
+// Thinking Block (collapsible)
+// ============================================
+
+function AgentThinkingBlock({ content }: { content: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="agent-block-thinking">
+      <button
+        className="agent-thinking-trigger"
+        onClick={() => setOpen(!open)}
+      >
+        {open ? '\u25BC' : '\u25B6'} Thinking...
+      </button>
+      {open && <div className="agent-thinking-content">{content}</div>}
+    </div>
+  );
+}
+
+// ============================================
+// Tool View (dispatches to specialized views)
+// ============================================
+
+function AgentToolView({ block }: { block: AgentToolBlockType }) {
+  const [open, setOpen] = useState(true);
+  const toolMeta = KNOWN_TOOLS[block.toolName] ?? { label: block.toolName };
+
+  return (
+    <div className="agent-block-tool" data-status={block.status}>
+      <button className="agent-tool-trigger" onClick={() => setOpen(!open)}>
+        <span className="agent-tool-name">{toolMeta.label}</span>
+        <span className="agent-tool-status">
+          {block.status === 'running' ? (
+            <span className="agent-spinner" />
+          ) : block.status === 'completed' ? (
+            '\u2713'
+          ) : (
+            '\u2717'
+          )}
+        </span>
+      </button>
+      {open && (
+        <div className="agent-tool-content">
+          <AgentToolDetail block={block} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AgentToolDetail({ block }: { block: AgentToolBlockType }) {
+  switch (block.toolName) {
+    case 'bash':
+      return (
+        <div className="agent-tool-bash">
+          <div className="bash-command">$ {String(block.args.command ?? '')}</div>
+          {block.result && (
+            <pre className="bash-output">{String(block.result.content ?? '')}</pre>
+          )}
+        </div>
+      );
+
+    case 'edit':
+      return (
+        <div className="agent-tool-edit">
+          <div className="edit-path">{String(block.args.file_path ?? block.args.path ?? '')}</div>
+          {block.result && (
+            <pre className="edit-result">{String(block.result.content ?? '')}</pre>
+          )}
+        </div>
+      );
+
+    case 'read':
+      return (
+        <div className="agent-tool-read">
+          <div className="read-path">{String(block.args.file_path ?? block.args.path ?? '')}</div>
+          {block.args.offset && (
+            <span className="read-range">
+              lines {String(block.args.offset)}-
+              {String(Number(block.args.offset) + Number(block.args.limit || 2000))}
+            </span>
+          )}
+        </div>
+      );
+
+    case 'write':
+      return (
+        <div className="agent-tool-write">
+          <div className="write-path">{String(block.args.file_path ?? block.args.path ?? '')}</div>
+          <span className="write-size">
+            {String(block.args.content ?? '').length} bytes
+          </span>
+        </div>
+      );
+
+    case 'grep':
+      return (
+        <div className="agent-tool-grep">
+          <div className="grep-pattern">{String(block.args.pattern ?? '')}</div>
+          {block.args.path && (
+            <span className="grep-path">in {String(block.args.path)}</span>
+          )}
+          {block.result && (
+            <pre className="grep-result">{String(block.result.content ?? '')}</pre>
+          )}
+        </div>
+      );
+
+    case 'find':
+    case 'ls':
+      return (
+        <div className="agent-tool-generic">
+          <pre className="tool-args">{JSON.stringify(block.args, null, 2)}</pre>
+          {block.result && (
+            <pre className="tool-result">{String(block.result.content ?? '')}</pre>
+          )}
+        </div>
+      );
+
+    default:
+      // Generic view for unknown/dynamic tools
+      return (
+        <div className="agent-tool-generic">
+          <div className="tool-name-label">{block.toolName}</div>
+          <pre className="tool-args">{JSON.stringify(block.args, null, 2)}</pre>
+          {block.result && (
+            <pre className="tool-result">
+              {typeof block.result.content === 'string'
+                ? block.result.content
+                : JSON.stringify(block.result.content, null, 2)}
+            </pre>
+          )}
+        </div>
+      );
+  }
+}
+
+// ============================================
+// Steer Input
+// ============================================
+
+function SteerInput({ onSubmit }: { onSubmit: (msg: string) => void }) {
+  const [value, setValue] = useState('');
+  return (
+    <form
+      className="agent-steer-input"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (value.trim()) {
+          onSubmit(value);
+          setValue('');
+        }
+      }}
+    >
+      <input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Steer the agent..."
+      />
+      <button type="submit">Send</button>
+    </form>
+  );
+}

--- a/src/renderer/chat/components/AgentRunBlock.tsx
+++ b/src/renderer/chat/components/AgentRunBlock.tsx
@@ -58,7 +58,7 @@ export function AgentRunBlock({ message, onSteer, onAbort }: AgentRunBlockProps)
           </span>
         )}
         {message.status === 'running' && onAbort && (
-          <button className="agent-abort-btn" onClick={onAbort}>
+          <button className="agent-abort-btn" onClick={onAbort} aria-label="Abort agent run">
             Abort
           </button>
         )}
@@ -138,6 +138,8 @@ function AgentThinkingBlock({ content }: { content: string }) {
       <button
         className="agent-thinking-trigger"
         onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-label="Toggle thinking details"
       >
         {open ? '\u25BC' : '\u25B6'} Thinking...
       </button>
@@ -156,7 +158,7 @@ function AgentToolView({ block }: { block: AgentToolBlockType }) {
 
   return (
     <div className="agent-block-tool" data-status={block.status}>
-      <button className="agent-tool-trigger" onClick={() => setOpen(!open)}>
+      <button className="agent-tool-trigger" onClick={() => setOpen(!open)} aria-expanded={open} aria-label={`Toggle ${toolMeta.label} details`}>
         <span className="agent-tool-name">{toolMeta.label}</span>
         <span className="agent-tool-status">
           {block.status === 'running' ? (
@@ -191,6 +193,8 @@ function TruncatedPre({ content, className }: { content: string; className?: str
         <button
           className="agent-truncate-toggle"
           onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+          aria-label={expanded ? 'Show less content' : 'Show more content'}
         >
           {expanded ? 'Show less' : 'Show more'}
         </button>

--- a/src/renderer/chat/components/AgentRunBlock.tsx
+++ b/src/renderer/chat/components/AgentRunBlock.tsx
@@ -8,6 +8,9 @@
 import { useState } from 'react';
 import type { AgentRunMessage, AgentBlock, AgentToolBlock as AgentToolBlockType } from '../types';
 
+/** Max characters to show for tool results before truncating */
+const MAX_RESULT_LENGTH = 5000;
+
 // ============================================
 // Known tool display metadata
 // ============================================
@@ -174,6 +177,28 @@ function AgentToolView({ block }: { block: AgentToolBlockType }) {
   );
 }
 
+/** Pre block that truncates long content with a toggle */
+function TruncatedPre({ content, className }: { content: string; className?: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const truncated = content.length > MAX_RESULT_LENGTH;
+
+  return (
+    <>
+      <pre className={className}>
+        {truncated && !expanded ? content.slice(0, MAX_RESULT_LENGTH) + '\n... (truncated)' : content}
+      </pre>
+      {truncated && (
+        <button
+          className="agent-truncate-toggle"
+          onClick={() => setExpanded(!expanded)}
+        >
+          {expanded ? 'Show less' : 'Show more'}
+        </button>
+      )}
+    </>
+  );
+}
+
 function AgentToolDetail({ block }: { block: AgentToolBlockType }) {
   switch (block.toolName) {
     case 'bash':
@@ -181,7 +206,7 @@ function AgentToolDetail({ block }: { block: AgentToolBlockType }) {
         <div className="agent-tool-bash">
           <div className="bash-command">$ {String(block.args.command ?? '')}</div>
           {block.result && (
-            <pre className="bash-output">{String(block.result.content ?? '')}</pre>
+            <TruncatedPre className="bash-output" content={String(block.result.content ?? '')} />
           )}
         </div>
       );
@@ -191,7 +216,7 @@ function AgentToolDetail({ block }: { block: AgentToolBlockType }) {
         <div className="agent-tool-edit">
           <div className="edit-path">{String(block.args.file_path ?? block.args.path ?? '')}</div>
           {block.result && (
-            <pre className="edit-result">{String(block.result.content ?? '')}</pre>
+            <TruncatedPre className="edit-result" content={String(block.result.content ?? '')} />
           )}
         </div>
       );
@@ -227,7 +252,7 @@ function AgentToolDetail({ block }: { block: AgentToolBlockType }) {
             <span className="grep-path">in {String(block.args.path)}</span>
           )}
           {block.result && (
-            <pre className="grep-result">{String(block.result.content ?? '')}</pre>
+            <TruncatedPre className="grep-result" content={String(block.result.content ?? '')} />
           )}
         </div>
       );
@@ -238,7 +263,7 @@ function AgentToolDetail({ block }: { block: AgentToolBlockType }) {
         <div className="agent-tool-generic">
           <pre className="tool-args">{JSON.stringify(block.args, null, 2)}</pre>
           {block.result && (
-            <pre className="tool-result">{String(block.result.content ?? '')}</pre>
+            <TruncatedPre className="tool-result" content={String(block.result.content ?? '')} />
           )}
         </div>
       );
@@ -250,11 +275,14 @@ function AgentToolDetail({ block }: { block: AgentToolBlockType }) {
           <div className="tool-name-label">{block.toolName}</div>
           <pre className="tool-args">{JSON.stringify(block.args, null, 2)}</pre>
           {block.result && (
-            <pre className="tool-result">
-              {typeof block.result.content === 'string'
-                ? block.result.content
-                : JSON.stringify(block.result.content, null, 2)}
-            </pre>
+            <TruncatedPre
+              className="tool-result"
+              content={
+                typeof block.result.content === 'string'
+                  ? block.result.content
+                  : JSON.stringify(block.result.content, null, 2)
+              }
+            />
           )}
         </div>
       );

--- a/src/renderer/chat/components/ChatDrawer.tsx
+++ b/src/renderer/chat/components/ChatDrawer.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useRef, useCallback } from 'react';
 import { useChat } from '../context/ChatContext';
+import { useCodingAgent } from '../hooks/useCodingAgent';
 import { ChatOutput } from './ChatOutput';
 import { ChatInput } from './ChatInput';
 import { ServerStatus } from './ServerStatus';
@@ -34,6 +35,7 @@ interface ChatDrawerProps {
 
 export function ChatDrawer({ alwaysOpen = false }: ChatDrawerProps) {
   const { state, toggleDrawer, closeDrawer } = useChat();
+  const { steer: agentSteer, abort: agentAbort } = useCodingAgent();
   const [height, setHeight] = useState(() => Math.round(window.innerHeight * 0.6));
   const drawerRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
@@ -129,7 +131,12 @@ export function ChatDrawer({ alwaysOpen = false }: ChatDrawerProps) {
         </div>
 
         {/* Content */}
-        <ChatOutput messages={state.messages} isProcessing={state.isProcessing} />
+        <ChatOutput
+          messages={state.messages}
+          isProcessing={state.isProcessing}
+          onAgentSteer={state.agentRun ? agentSteer : undefined}
+          onAgentAbort={state.agentRun ? agentAbort : undefined}
+        />
         <ChatInput />
 
         {/* Tool execution handler (renders nothing) */}

--- a/src/renderer/chat/components/ChatOutput.tsx
+++ b/src/renderer/chat/components/ChatOutput.tsx
@@ -3,18 +3,23 @@
  *
  * Scrollable area that displays chat messages.
  * Auto-scrolls to bottom on new messages.
+ * Routes messages to appropriate renderers based on type.
  */
 
 import { useRef, useEffect } from 'react';
 import type { ChatMessage } from '../types';
+import { isTextMessage } from '../types';
 import { MessageBubble } from './MessageBubble';
+import { AgentRunBlock } from './AgentRunBlock';
 
 interface ChatOutputProps {
   messages: ChatMessage[];
   isProcessing: boolean;
+  onAgentSteer?: (message: string) => void;
+  onAgentAbort?: () => void;
 }
 
-export function ChatOutput({ messages, isProcessing }: ChatOutputProps) {
+export function ChatOutput({ messages, isProcessing, onAgentSteer, onAgentAbort }: ChatOutputProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const shouldScrollRef = useRef(true);
 
@@ -50,12 +55,22 @@ export function ChatOutput({ messages, isProcessing }: ChatOutputProps) {
           </p>
         </div>
       ) : (
-        messages.map((message) => (
-          <MessageBubble key={message.id} message={message} />
-        ))
+        messages.map((message) => {
+          if (isTextMessage(message)) {
+            return <MessageBubble key={message.id} message={message} />;
+          }
+          return (
+            <AgentRunBlock
+              key={message.id}
+              message={message}
+              onSteer={message.status === 'running' ? onAgentSteer : undefined}
+              onAbort={message.status === 'running' ? onAgentAbort : undefined}
+            />
+          );
+        })
       )}
 
-      {isProcessing && !messages.some((m) => m.isStreaming) && (
+      {isProcessing && !messages.some((m) => isTextMessage(m) && m.isStreaming) && (
         <div className="chat-typing">
           <span className="chat-typing-dot" />
           <span className="chat-typing-dot" />

--- a/src/renderer/chat/components/MessageBubble.tsx
+++ b/src/renderer/chat/components/MessageBubble.tsx
@@ -4,11 +4,11 @@
  * Renders a single chat message with optional tool calls.
  */
 
-import type { ChatMessage } from '../types';
+import type { ChatTextMessage } from '../types';
 import { ToolCallBlock } from './ToolCallBlock';
 
 interface MessageBubbleProps {
-  message: ChatMessage;
+  message: ChatTextMessage;
 }
 
 export function MessageBubble({ message }: MessageBubbleProps) {

--- a/src/renderer/chat/components/ToolExecutor.tsx
+++ b/src/renderer/chat/components/ToolExecutor.tsx
@@ -9,6 +9,7 @@
 import { useEffect, useRef } from 'react';
 import { useChat } from '../context/ChatContext';
 import { useToolExecution } from '../hooks';
+import { isTextMessage } from '../types';
 
 export function ToolExecutor() {
   const { state } = useChat();
@@ -16,8 +17,11 @@ export function ToolExecutor() {
   const executingRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    // Find messages that have finished streaming and have pending tool calls
+    // Find text messages that have finished streaming and have pending tool calls
     for (const message of state.messages) {
+      // Skip agent-run messages — they handle their own tools
+      if (!isTextMessage(message)) continue;
+
       // Skip if still streaming
       if (message.isStreaming) continue;
 

--- a/src/renderer/chat/components/index.ts
+++ b/src/renderer/chat/components/index.ts
@@ -12,3 +12,4 @@ export { ToolCallBlock } from './ToolCallBlock';
 export { ServerStatus } from './ServerStatus';
 export { ThemeToggle } from './ThemeToggle';
 export { ToolExecutor } from './ToolExecutor';
+export { AgentRunBlock } from './AgentRunBlock';

--- a/src/renderer/chat/context/ChatContext.tsx
+++ b/src/renderer/chat/context/ChatContext.tsx
@@ -478,6 +478,14 @@ export function ChatProvider({ children }: ChatProviderProps) {
       let processedContent = content.trim();
 
       // Check for /code command — hand off to coding agent
+      if (processedContent === '/code') {
+        addMessage({
+          type: 'text',
+          role: 'system',
+          content: 'Usage: `/code <task>` - Hand off a coding task to the autonomous coding agent.',
+        });
+        return;
+      }
       if (processedContent.startsWith('/code ')) {
         const codeTask = processedContent.slice(6).trim();
         if (codeTask) {

--- a/src/renderer/chat/context/ChatContext.tsx
+++ b/src/renderer/chat/context/ChatContext.tsx
@@ -483,11 +483,10 @@ export function ChatProvider({ children }: ChatProviderProps) {
           dispatch({ type: 'ADD_TO_HISTORY', value: content });
           dispatch({ type: 'SET_INPUT', value: '' });
           addMessage({ type: 'text', role: 'user', content });
-          // Agent run is started via useCodingAgent hook — dispatch the start action
+          // Dispatch AGENT_RUN_START — the useCodingAgent hook watches for
+          // state.agentRun and auto-triggers the pi subprocess + IPC event wiring
           const messageId = generateId();
           dispatch({ type: 'AGENT_RUN_START', task: codeTask, messageId });
-          // The actual pi subprocess execution is handled by the useCodingAgent hook
-          // which listens for AGENT_RUN_START and drives the adapter
           return;
         }
         addMessage({

--- a/src/renderer/chat/context/ChatContext.tsx
+++ b/src/renderer/chat/context/ChatContext.tsx
@@ -188,7 +188,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
       return { ...state, error: action.error };
 
     case 'CLEAR_MESSAGES':
-      return { ...state, messages: [] };
+      return { ...state, messages: [], agentRun: null };
 
     case 'NEW_SESSION':
       return {
@@ -197,6 +197,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
         messages: [],
         error: null,
         currentTurn: 0,
+        agentRun: null,
       };
 
     case 'INCREMENT_TURN':

--- a/src/renderer/chat/context/ChatContext.tsx
+++ b/src/renderer/chat/context/ChatContext.tsx
@@ -22,11 +22,15 @@ import type {
   ChatState,
   ChatAction,
   ChatMessage,
+  ChatTextMessage,
   ChatToolCall,
   ServerInfo,
   McpTool,
   MessageModelConfig,
+  AgentRunMessage,
+  AgentBlock,
 } from '../types';
+import { isTextMessage } from '../types';
 import { useSettings } from '../../settings';
 import { useCommunication } from '../../hooks/useCommunication';
 import type { StreamEvent } from '../../../shared/types';
@@ -57,6 +61,7 @@ const initialState: ChatState = {
   activeServers: null,
   error: null,
   currentTurn: 0,
+  agentRun: null,
 };
 
 // ============================================
@@ -134,7 +139,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
       return {
         ...state,
         messages: state.messages.map((msg) =>
-          msg.id === action.id
+          msg.id === action.id && isTextMessage(msg)
             ? { ...msg, content: msg.content + action.content }
             : msg
         ),
@@ -144,7 +149,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
       return {
         ...state,
         messages: state.messages.map((msg) => {
-          if (msg.id !== action.messageId || !msg.toolCalls) return msg;
+          if (msg.id !== action.messageId || !isTextMessage(msg) || !msg.toolCalls) return msg;
           return {
             ...msg,
             toolCalls: msg.toolCalls.map((tc) =>
@@ -204,7 +209,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
       return {
         ...state,
         messages: state.messages.map((msg) => {
-          if (msg.id !== action.messageId) return msg;
+          if (msg.id !== action.messageId || !isTextMessage(msg)) return msg;
           const existingToolCalls = msg.toolCalls || [];
           return {
             ...msg,
@@ -213,9 +218,163 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
         }),
       };
 
+    // ============================================
+    // Agent Run Actions
+    // ============================================
+
+    case 'AGENT_RUN_START': {
+      const agentMsg: AgentRunMessage = {
+        type: 'agent-run',
+        id: action.messageId,
+        timestamp: new Date().toISOString(),
+        task: action.task,
+        status: 'running',
+        blocks: [],
+        statuses: {},
+        model: action.model,
+      };
+      return {
+        ...state,
+        messages: [...state.messages, agentMsg],
+        isProcessing: true,
+        agentRun: {
+          messageId: action.messageId,
+          task: action.task,
+          canSteer: true,
+          canAbort: true,
+        },
+      };
+    }
+
+    case 'AGENT_RUN_COMPLETE':
+      return {
+        ...state,
+        messages: state.messages.map((m) =>
+          m.id === action.messageId && m.type === 'agent-run'
+            ? { ...m, status: 'completed' as const, usage: action.usage }
+            : m
+        ),
+        isProcessing: false,
+        agentRun: null,
+      };
+
+    case 'AGENT_RUN_ERROR':
+      return {
+        ...state,
+        messages: state.messages.map((m) =>
+          m.id === action.messageId && m.type === 'agent-run'
+            ? { ...m, status: 'error' as const, error: action.error }
+            : m
+        ),
+        isProcessing: false,
+        agentRun: null,
+      };
+
+    case 'AGENT_RUN_ABORT':
+      return {
+        ...state,
+        messages: state.messages.map((m) =>
+          m.id === action.messageId && m.type === 'agent-run'
+            ? { ...m, status: 'aborted' as const }
+            : m
+        ),
+        isProcessing: false,
+        agentRun: null,
+      };
+
+    case 'AGENT_BLOCK_TEXT_DELTA':
+      return updateAgentBlocks(state, action.messageId, (blocks) => {
+        const last = blocks[blocks.length - 1];
+        if (last?.type === 'text') {
+          return [...blocks.slice(0, -1), { ...last, content: last.content + action.delta }];
+        }
+        return [...blocks, { type: 'text', content: action.delta }];
+      });
+
+    case 'AGENT_BLOCK_THINKING_DELTA':
+      return updateAgentBlocks(state, action.messageId, (blocks) => {
+        const last = blocks[blocks.length - 1];
+        if (last?.type === 'thinking') {
+          return [...blocks.slice(0, -1), { ...last, content: last.content + action.delta }];
+        }
+        return [...blocks, { type: 'thinking', content: action.delta }];
+      });
+
+    case 'AGENT_BLOCK_TOOL_START':
+      return updateAgentBlocks(state, action.messageId, (blocks) => [
+        ...blocks,
+        {
+          type: 'tool',
+          toolCallId: action.toolCallId,
+          toolName: action.toolName,
+          args: action.args,
+          status: 'running' as const,
+        },
+      ]);
+
+    case 'AGENT_BLOCK_TOOL_END':
+      return updateAgentBlocks(state, action.messageId, (blocks) =>
+        blocks.map((b) =>
+          b.type === 'tool' && b.toolCallId === action.toolCallId
+            ? {
+                ...b,
+                status: (action.isError ? 'error' : 'completed') as const,
+                result: { content: action.result, isError: action.isError },
+              }
+            : b
+        )
+      );
+
+    case 'AGENT_BLOCK_STATUS':
+      return updateAgentBlocks(state, action.messageId, (blocks) => [
+        ...blocks,
+        { type: 'status', message: action.message },
+      ]);
+
+    case 'AGENT_SET_STATUS':
+      return {
+        ...state,
+        messages: state.messages.map((m) => {
+          if (m.id !== action.messageId || m.type !== 'agent-run') return m;
+          const statuses = { ...m.statuses };
+          if (action.statusText === undefined) {
+            delete statuses[action.statusKey];
+          } else {
+            statuses[action.statusKey] = action.statusText;
+          }
+          return { ...m, statuses };
+        }),
+      };
+
+    case 'AGENT_SET_TITLE':
+      return {
+        ...state,
+        messages: state.messages.map((m) =>
+          m.id === action.messageId && m.type === 'agent-run'
+            ? { ...m, title: action.title }
+            : m
+        ),
+      };
+
     default:
       return state;
   }
+}
+
+/** Helper: update the blocks array of an AgentRunMessage */
+function updateAgentBlocks(
+  state: ChatState,
+  messageId: string,
+  updater: (blocks: AgentBlock[]) => AgentBlock[]
+): ChatState {
+  return {
+    ...state,
+    messages: state.messages.map((m) =>
+      m.id === messageId && m.type === 'agent-run'
+        ? { ...m, blocks: updater(m.blocks) }
+        : m
+    ),
+  };
 }
 
 // ============================================
@@ -231,8 +390,8 @@ interface ChatContextValue {
   closeDrawer: () => void;
   setInput: (value: string) => void;
   sendMessage: (content: string) => void;
-  addMessage: (message: Omit<ChatMessage, 'id' | 'timestamp'>) => ChatMessage;
-  updateMessage: (id: string, updates: Partial<ChatMessage>) => void;
+  addMessage: (message: Omit<ChatTextMessage, 'id' | 'timestamp'>) => ChatTextMessage;
+  updateMessage: (id: string, updates: Partial<ChatTextMessage>) => void;
   appendStream: (id: string, content: string) => void;
   updateToolCall: (messageId: string, toolCallId: string, updates: Partial<ChatToolCall>) => void;
   navigateHistory: (direction: 'up' | 'down') => void;
@@ -276,8 +435,8 @@ export function ChatProvider({ children }: ChatProviderProps) {
   }, []);
 
   const addMessage = useCallback(
-    (message: Omit<ChatMessage, 'id' | 'timestamp'>): ChatMessage => {
-      const fullMessage: ChatMessage = {
+    (message: Omit<ChatTextMessage, 'id' | 'timestamp'>): ChatTextMessage => {
+      const fullMessage: ChatTextMessage = {
         ...message,
         id: generateId(),
         timestamp: new Date().toISOString(),
@@ -289,7 +448,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
   );
 
   const updateMessage = useCallback(
-    (id: string, updates: Partial<ChatMessage>) => {
+    (id: string, updates: Partial<ChatTextMessage>) => {
       dispatch({ type: 'UPDATE_MESSAGE', id, updates });
     },
     []
@@ -317,12 +476,35 @@ export function ChatProvider({ children }: ChatProviderProps) {
       let modelRole: 'doer' | 'dreamer' = 'doer';
       let processedContent = content.trim();
 
+      // Check for /code command — hand off to coding agent
+      if (processedContent.startsWith('/code ')) {
+        const codeTask = processedContent.slice(6).trim();
+        if (codeTask) {
+          dispatch({ type: 'ADD_TO_HISTORY', value: content });
+          dispatch({ type: 'SET_INPUT', value: '' });
+          addMessage({ type: 'text', role: 'user', content });
+          // Agent run is started via useCodingAgent hook — dispatch the start action
+          const messageId = generateId();
+          dispatch({ type: 'AGENT_RUN_START', task: codeTask, messageId });
+          // The actual pi subprocess execution is handled by the useCodingAgent hook
+          // which listens for AGENT_RUN_START and drives the adapter
+          return;
+        }
+        addMessage({
+          type: 'text',
+          role: 'system',
+          content: 'Usage: `/code <task>` - Hand off a coding task to the autonomous coding agent.',
+        });
+        return;
+      }
+
       if (processedContent.startsWith('/dream ')) {
         modelRole = 'dreamer';
         processedContent = processedContent.slice(7).trim();
       } else if (processedContent === '/dream') {
         // Just "/dream" with no content - show help
         addMessage({
+          type: 'text',
           role: 'system',
           content: 'Usage: `/dream <your question>` - Use the Dreamer model for complex reasoning.',
         });
@@ -337,7 +519,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
       dispatch({ type: 'SET_INPUT', value: '' });
       dispatch({ type: 'RESET_TURN' }); // Reset turn counter for new user message
       continuationTriggeredRef.current.clear(); // Clear continuation tracking for new conversation turn
-      addMessage({ role: 'user', content });
+      addMessage({ type: 'text', role: 'user', content });
 
       // Create assistant message placeholder with model config for continuation
       const msgModelConfig: MessageModelConfig = {
@@ -347,6 +529,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
         maxTurns: modelConfig.maxTurns,
       };
       const assistantMsg = addMessage({
+        type: 'text',
         role: 'assistant',
         content: '',
         isStreaming: true,
@@ -364,6 +547,8 @@ export function ChatProvider({ children }: ChatProviderProps) {
         }> = [];
 
         for (const m of state.messages) {
+          // Skip agent-run messages — they are self-contained
+          if (!isTextMessage(m)) continue;
           if (m.role === 'system') continue;
 
           if (m.role === 'user') {
@@ -484,7 +669,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     async (messageId: string) => {
       // Find the message we're continuing from
       const message = state.messages.find((m) => m.id === messageId);
-      if (!message || message.role !== 'assistant') {
+      if (!message || !isTextMessage(message) || message.role !== 'assistant') {
         console.warn('[Chat] continueAfterTools: Invalid message', messageId);
         return;
       }
@@ -532,6 +717,8 @@ export function ChatProvider({ children }: ChatProviderProps) {
         }> = [];
 
         for (const m of state.messages) {
+          // Skip agent-run messages — they are self-contained
+          if (!isTextMessage(m)) continue;
           if (m.role === 'system') continue;
 
           if (m.role === 'user') {
@@ -662,8 +849,10 @@ export function ChatProvider({ children }: ChatProviderProps) {
     // Skip if processing (already continuing or waiting for stream)
     if (state.isProcessing) return;
 
-    // Find the last assistant message
-    const lastAssistantMsg = [...state.messages].reverse().find((m) => m.role === 'assistant');
+    // Find the last assistant text message (skip agent-run messages)
+    const lastAssistantMsg = [...state.messages].reverse().find(
+      (m): m is ChatTextMessage => isTextMessage(m) && m.role === 'assistant'
+    );
     if (!lastAssistantMsg) return;
 
     // Skip if streaming

--- a/src/renderer/chat/context/ChatContext.tsx
+++ b/src/renderer/chat/context/ChatContext.tsx
@@ -288,7 +288,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
         if (last?.type === 'text') {
           return [...blocks.slice(0, -1), { ...last, content: last.content + action.delta }];
         }
-        return [...blocks, { type: 'text', content: action.delta }];
+        return [...blocks, { type: 'text', id: generateId(), content: action.delta }];
       });
 
     case 'AGENT_BLOCK_THINKING_DELTA':
@@ -297,7 +297,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
         if (last?.type === 'thinking') {
           return [...blocks.slice(0, -1), { ...last, content: last.content + action.delta }];
         }
-        return [...blocks, { type: 'thinking', content: action.delta }];
+        return [...blocks, { type: 'thinking', id: generateId(), content: action.delta }];
       });
 
     case 'AGENT_BLOCK_TOOL_START':
@@ -328,7 +328,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
     case 'AGENT_BLOCK_STATUS':
       return updateAgentBlocks(state, action.messageId, (blocks) => [
         ...blocks,
-        { type: 'status', message: action.message },
+        { type: 'status', id: generateId(), message: action.message },
       ]);
 
     case 'AGENT_SET_STATUS':

--- a/src/renderer/chat/hooks/index.ts
+++ b/src/renderer/chat/hooks/index.ts
@@ -4,4 +4,4 @@
 
 export { useThemeTools, isThemeTool, type ThemeToolResult } from './useThemeTools';
 export { useToolExecution, type ToolExecutionResult } from './useToolExecution';
-export { useCodingAgent, handleAgentEvent } from './useCodingAgent';
+export { useCodingAgent } from './useCodingAgent';

--- a/src/renderer/chat/hooks/index.ts
+++ b/src/renderer/chat/hooks/index.ts
@@ -4,3 +4,4 @@
 
 export { useThemeTools, isThemeTool, type ThemeToolResult } from './useThemeTools';
 export { useToolExecution, type ToolExecutionResult } from './useToolExecution';
+export { useCodingAgent, handleAgentEvent } from './useCodingAgent';

--- a/src/renderer/chat/hooks/useCodingAgent.ts
+++ b/src/renderer/chat/hooks/useCodingAgent.ts
@@ -27,18 +27,6 @@ export function useCodingAgent() {
   const steerRef = useRef<((msg: string) => void) | null>(null);
   const startedRef = useRef(false);
 
-  // Wire up IPC event listener — subscribe when an agent run is active
-  useEffect(() => {
-    const api = window.electronAPI;
-    if (!api?.codingAgent || !state.agentRun) return;
-
-    const messageId = state.agentRun.messageId;
-    const unsub = api.codingAgent.onEvent((event) => {
-      handleAgentEvent(dispatch, messageId, event as AgentEvent);
-    });
-    return unsub;
-  }, [dispatch, state.agentRun]);
-
   const startRun = useCallback(
     async (task: string, messageId: string) => {
       const api = window.electronAPI;
@@ -55,6 +43,12 @@ export function useCodingAgent() {
       abortRef.current = () => api.codingAgent.abort();
       steerRef.current = (msg) => api.codingAgent.steer(msg);
 
+      // Subscribe to events BEFORE calling execute() to avoid race condition
+      // where early events could be missed if the listener isn't set up yet.
+      const unsub = api.codingAgent.onEvent((event) => {
+        handleAgentEvent(dispatch, messageId, event as AgentEvent);
+      });
+
       try {
         // Start the pi subprocess — cwd defaults to main process cwd
         await api.codingAgent.start({});
@@ -65,6 +59,7 @@ export function useCodingAgent() {
         const msg = err instanceof Error ? err.message : 'Unknown error';
         dispatch({ type: 'AGENT_RUN_ERROR', messageId, error: msg });
       } finally {
+        unsub();
         abortRef.current = null;
         steerRef.current = null;
       }
@@ -96,7 +91,7 @@ export function useCodingAgent() {
 
 /**
  * Handles a single agent event by dispatching the appropriate reducer action.
- * Called from the IPC event listener setup in the preload/main bridge.
+ * Called from the IPC event listener setup in startRun.
  */
 export function handleAgentEvent(
   dispatch: Dispatch<ChatAction>,
@@ -193,10 +188,19 @@ export function handleAgentEvent(
       console.log('[CodingAgent] set_widget:', event.widgetKey);
       break;
 
-    case 'ui_request':
-      // TODO: Handle extension UI requests (select, confirm, input, editor)
-      // For now, log them
-      console.log('[CodingAgent] UI request:', event);
+    case 'ui_request': {
+      // Auto-cancel unhandled UI requests so pi doesn't block indefinitely.
+      // TODO: Implement proper UI for select, confirm, input, editor requests.
+      const api = window.electronAPI;
+      if (api?.codingAgent && event.id) {
+        api.codingAgent.respondToUIRequest({
+          type: 'extension_ui_response',
+          id: event.id as string,
+          cancelled: true,
+        });
+      }
+      console.warn('[CodingAgent] Auto-cancelled unhandled UI request:', event.method);
       break;
+    }
   }
 }

--- a/src/renderer/chat/hooks/useCodingAgent.ts
+++ b/src/renderer/chat/hooks/useCodingAgent.ts
@@ -21,6 +21,9 @@ interface AgentEvent {
   [key: string]: unknown;
 }
 
+/** Track aborted message IDs so post-abort events are ignored */
+const abortedMessageIds = new Set<string>();
+
 export function useCodingAgent() {
   const { dispatch, state } = useChat();
   const abortRef = useRef<(() => void) | null>(null);
@@ -83,8 +86,12 @@ export function useCodingAgent() {
   }, []);
 
   const abort = useCallback(async () => {
-    await abortRef.current?.();
-  }, []);
+    if (abortRef.current && state.agentRun) {
+      abortedMessageIds.add(state.agentRun.messageId);
+      dispatch({ type: 'AGENT_RUN_ABORT', messageId: state.agentRun.messageId });
+      await abortRef.current();
+    }
+  }, [state.agentRun, dispatch]);
 
   return { steer, abort };
 }
@@ -98,6 +105,15 @@ export function handleAgentEvent(
   messageId: string,
   event: AgentEvent
 ): void {
+  // Ignore events for messages that were already aborted
+  if (abortedMessageIds.has(messageId)) {
+    if (event.type === 'complete' || event.type === 'error') {
+      // Terminal event — clean up tracking
+      abortedMessageIds.delete(messageId);
+    }
+    return;
+  }
+
   switch (event.type) {
     case 'text_delta': {
       const textDelta = typeof event.delta === 'string' ? event.delta : '';

--- a/src/renderer/chat/hooks/useCodingAgent.ts
+++ b/src/renderer/chat/hooks/useCodingAgent.ts
@@ -21,14 +21,13 @@ interface AgentEvent {
   [key: string]: unknown;
 }
 
-/** Track aborted message IDs so post-abort events are ignored */
-const abortedMessageIds = new Set<string>();
-
 export function useCodingAgent() {
   const { dispatch, state } = useChat();
   const abortRef = useRef<(() => void) | null>(null);
   const steerRef = useRef<((msg: string) => void) | null>(null);
   const startedRef = useRef(false);
+  /** Track aborted message IDs so post-abort events are ignored */
+  const abortedMessageIdsRef = useRef(new Set<string>());
 
   const startRun = useCallback(
     async (task: string, messageId: string) => {
@@ -48,8 +47,9 @@ export function useCodingAgent() {
 
       // Subscribe to events BEFORE calling execute() to avoid race condition
       // where early events could be missed if the listener isn't set up yet.
+      const abortedIds = abortedMessageIdsRef.current;
       const unsub = api.codingAgent.onEvent((event) => {
-        handleAgentEvent(dispatch, messageId, event as AgentEvent);
+        handleAgentEvent(dispatch, messageId, event as AgentEvent, abortedIds);
       });
 
       try {
@@ -80,7 +80,7 @@ export function useCodingAgent() {
       startedRef.current = false;
       // Clean up stale aborted IDs when no run is active — prevents
       // unbounded growth if a process crashes before sending a terminal event.
-      abortedMessageIds.clear();
+      abortedMessageIdsRef.current.clear();
     }
   }, [state.agentRun, startRun]);
 
@@ -90,7 +90,7 @@ export function useCodingAgent() {
 
   const abort = useCallback(async () => {
     if (abortRef.current && state.agentRun) {
-      abortedMessageIds.add(state.agentRun.messageId);
+      abortedMessageIdsRef.current.add(state.agentRun.messageId);
       dispatch({ type: 'AGENT_RUN_ABORT', messageId: state.agentRun.messageId });
       await abortRef.current();
     }
@@ -103,10 +103,11 @@ export function useCodingAgent() {
  * Handles a single agent event by dispatching the appropriate reducer action.
  * Called from the IPC event listener setup in startRun.
  */
-export function handleAgentEvent(
+function handleAgentEvent(
   dispatch: Dispatch<ChatAction>,
   messageId: string,
-  event: AgentEvent
+  event: AgentEvent,
+  abortedMessageIds: Set<string>
 ): void {
   // Ignore events for messages that were already aborted
   if (abortedMessageIds.has(messageId)) {

--- a/src/renderer/chat/hooks/useCodingAgent.ts
+++ b/src/renderer/chat/hooks/useCodingAgent.ts
@@ -3,9 +3,14 @@
  *
  * Bridges the coding agent adapter (IPC) to ChatContext dispatch.
  * Translates agent events into reducer actions.
+ *
+ * Responsibilities:
+ * 1. Subscribe to IPC agent events and dispatch them to the reducer
+ * 2. Auto-trigger startRun when state.agentRun appears
+ * 3. Expose steer/abort controls for the UI
  */
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useChat } from '../context/ChatContext';
 import type { ChatAction } from '../types';
 import type { Dispatch } from 'react';
@@ -20,6 +25,19 @@ export function useCodingAgent() {
   const { dispatch, state } = useChat();
   const abortRef = useRef<(() => void) | null>(null);
   const steerRef = useRef<((msg: string) => void) | null>(null);
+  const startedRef = useRef(false);
+
+  // Wire up IPC event listener — subscribe when an agent run is active
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.codingAgent || !state.agentRun) return;
+
+    const messageId = state.agentRun.messageId;
+    const unsub = api.codingAgent.onEvent((event) => {
+      handleAgentEvent(dispatch, messageId, event as AgentEvent);
+    });
+    return unsub;
+  }, [dispatch, state.agentRun]);
 
   const startRun = useCallback(
     async (task: string, messageId: string) => {
@@ -38,12 +56,10 @@ export function useCodingAgent() {
       steerRef.current = (msg) => api.codingAgent.steer(msg);
 
       try {
-        // Start the pi subprocess
-        await api.codingAgent.start({
-          cwd: process.cwd?.() ?? '.',
-        });
+        // Start the pi subprocess — cwd defaults to main process cwd
+        await api.codingAgent.start({});
 
-        // Execute the task — events stream via IPC
+        // Execute the task — events stream via IPC onEvent listener
         await api.codingAgent.execute(task);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : 'Unknown error';
@@ -56,6 +72,17 @@ export function useCodingAgent() {
     [dispatch]
   );
 
+  // Auto-trigger startRun when a new agent run appears in state
+  useEffect(() => {
+    if (state.agentRun && !startedRef.current) {
+      startedRef.current = true;
+      startRun(state.agentRun.task, state.agentRun.messageId);
+    }
+    if (!state.agentRun) {
+      startedRef.current = false;
+    }
+  }, [state.agentRun, startRun]);
+
   const steer = useCallback(async (message: string) => {
     await steerRef.current?.(message);
   }, []);
@@ -64,7 +91,7 @@ export function useCodingAgent() {
     await abortRef.current?.();
   }, []);
 
-  return { startRun, steer, abort };
+  return { steer, abort };
 }
 
 /**
@@ -152,6 +179,18 @@ export function handleAgentEvent(
         messageId,
         error: event.message as string,
       });
+      break;
+
+    case 'tool_update':
+      // Partial tool results (e.g. streaming bash output) — log for now
+      // TODO: Add AGENT_BLOCK_TOOL_UPDATE reducer action for live streaming
+      console.log('[CodingAgent] tool_update:', event.toolCallId);
+      break;
+
+    case 'set_widget':
+      // Widget updates from extensions — log for now
+      // TODO: Add AGENT_SET_WIDGET reducer action for widget display
+      console.log('[CodingAgent] set_widget:', event.widgetKey);
       break;
 
     case 'ui_request':

--- a/src/renderer/chat/hooks/useCodingAgent.ts
+++ b/src/renderer/chat/hooks/useCodingAgent.ts
@@ -99,21 +99,29 @@ export function handleAgentEvent(
   event: AgentEvent
 ): void {
   switch (event.type) {
-    case 'text_delta':
-      dispatch({
-        type: 'AGENT_BLOCK_TEXT_DELTA',
-        messageId,
-        delta: event.delta as string,
-      });
+    case 'text_delta': {
+      const textDelta = typeof event.delta === 'string' ? event.delta : '';
+      if (textDelta) {
+        dispatch({
+          type: 'AGENT_BLOCK_TEXT_DELTA',
+          messageId,
+          delta: textDelta,
+        });
+      }
       break;
+    }
 
-    case 'thinking_delta':
-      dispatch({
-        type: 'AGENT_BLOCK_THINKING_DELTA',
-        messageId,
-        delta: event.delta as string,
-      });
+    case 'thinking_delta': {
+      const thinkingDelta = typeof event.delta === 'string' ? event.delta : '';
+      if (thinkingDelta) {
+        dispatch({
+          type: 'AGENT_BLOCK_THINKING_DELTA',
+          messageId,
+          delta: thinkingDelta,
+        });
+      }
       break;
+    }
 
     case 'tool_start':
       dispatch({

--- a/src/renderer/chat/hooks/useCodingAgent.ts
+++ b/src/renderer/chat/hooks/useCodingAgent.ts
@@ -78,6 +78,9 @@ export function useCodingAgent() {
     }
     if (!state.agentRun) {
       startedRef.current = false;
+      // Clean up stale aborted IDs when no run is active — prevents
+      // unbounded growth if a process crashes before sending a terminal event.
+      abortedMessageIds.clear();
     }
   }, [state.agentRun, startRun]);
 

--- a/src/renderer/chat/hooks/useCodingAgent.ts
+++ b/src/renderer/chat/hooks/useCodingAgent.ts
@@ -1,0 +1,163 @@
+/**
+ * useCodingAgent Hook
+ *
+ * Bridges the coding agent adapter (IPC) to ChatContext dispatch.
+ * Translates agent events into reducer actions.
+ */
+
+import { useCallback, useRef } from 'react';
+import { useChat } from '../context/ChatContext';
+import type { ChatAction } from '../types';
+import type { Dispatch } from 'react';
+
+/** Agent event shape received from IPC (mirrors AgentEvent from adapter.ts) */
+interface AgentEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+export function useCodingAgent() {
+  const { dispatch, state } = useChat();
+  const abortRef = useRef<(() => void) | null>(null);
+  const steerRef = useRef<((msg: string) => void) | null>(null);
+
+  const startRun = useCallback(
+    async (task: string, messageId: string) => {
+      const api = window.electronAPI;
+      if (!api?.codingAgent) {
+        dispatch({
+          type: 'AGENT_RUN_ERROR',
+          messageId,
+          error: 'Coding agent not available (requires Electron)',
+        });
+        return;
+      }
+
+      // Store controls
+      abortRef.current = () => api.codingAgent.abort();
+      steerRef.current = (msg) => api.codingAgent.steer(msg);
+
+      try {
+        // Start the pi subprocess
+        await api.codingAgent.start({
+          cwd: process.cwd?.() ?? '.',
+        });
+
+        // Execute the task — events stream via IPC
+        await api.codingAgent.execute(task);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'Unknown error';
+        dispatch({ type: 'AGENT_RUN_ERROR', messageId, error: msg });
+      } finally {
+        abortRef.current = null;
+        steerRef.current = null;
+      }
+    },
+    [dispatch]
+  );
+
+  const steer = useCallback(async (message: string) => {
+    await steerRef.current?.(message);
+  }, []);
+
+  const abort = useCallback(async () => {
+    await abortRef.current?.();
+  }, []);
+
+  return { startRun, steer, abort };
+}
+
+/**
+ * Handles a single agent event by dispatching the appropriate reducer action.
+ * Called from the IPC event listener setup in the preload/main bridge.
+ */
+export function handleAgentEvent(
+  dispatch: Dispatch<ChatAction>,
+  messageId: string,
+  event: AgentEvent
+): void {
+  switch (event.type) {
+    case 'text_delta':
+      dispatch({
+        type: 'AGENT_BLOCK_TEXT_DELTA',
+        messageId,
+        delta: event.delta as string,
+      });
+      break;
+
+    case 'thinking_delta':
+      dispatch({
+        type: 'AGENT_BLOCK_THINKING_DELTA',
+        messageId,
+        delta: event.delta as string,
+      });
+      break;
+
+    case 'tool_start':
+      dispatch({
+        type: 'AGENT_BLOCK_TOOL_START',
+        messageId,
+        toolCallId: event.toolCallId as string,
+        toolName: event.toolName as string,
+        args: (event.args as Record<string, unknown>) ?? {},
+      });
+      break;
+
+    case 'tool_end':
+      dispatch({
+        type: 'AGENT_BLOCK_TOOL_END',
+        messageId,
+        toolCallId: event.toolCallId as string,
+        result: event.result,
+        isError: (event.isError as boolean) ?? false,
+      });
+      break;
+
+    case 'status':
+      dispatch({
+        type: 'AGENT_BLOCK_STATUS',
+        messageId,
+        message: event.message as string,
+      });
+      break;
+
+    case 'set_status':
+      dispatch({
+        type: 'AGENT_SET_STATUS',
+        messageId,
+        statusKey: event.statusKey as string,
+        statusText: event.statusText as string | undefined,
+      });
+      break;
+
+    case 'set_title':
+      dispatch({
+        type: 'AGENT_SET_TITLE',
+        messageId,
+        title: event.title as string,
+      });
+      break;
+
+    case 'complete':
+      dispatch({
+        type: 'AGENT_RUN_COMPLETE',
+        messageId,
+        usage: event.usage as { inputTokens: number; outputTokens: number; totalCost: number } | undefined,
+      });
+      break;
+
+    case 'error':
+      dispatch({
+        type: 'AGENT_RUN_ERROR',
+        messageId,
+        error: event.message as string,
+      });
+      break;
+
+    case 'ui_request':
+      // TODO: Handle extension UI requests (select, confirm, input, editor)
+      // For now, log them
+      console.log('[CodingAgent] UI request:', event);
+      break;
+  }
+}

--- a/src/renderer/chat/main.css
+++ b/src/renderer/chat/main.css
@@ -1299,6 +1299,15 @@
   opacity: 0.9;
 }
 
+/* Focus styles for keyboard accessibility */
+.agent-abort-btn:focus-visible,
+.agent-thinking-trigger:focus-visible,
+.agent-tool-trigger:focus-visible,
+.agent-truncate-toggle:focus-visible {
+  outline: 2px solid var(--chat-accent);
+  outline-offset: 2px;
+}
+
 .agent-run-task {
   color: var(--chat-text-muted);
   font-size: var(--font-size-sm);

--- a/src/renderer/chat/main.css
+++ b/src/renderer/chat/main.css
@@ -1425,7 +1425,7 @@
 }
 
 .agent-tool-trigger:hover {
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: var(--chat-bg-secondary);
 }
 
 .agent-tool-name {

--- a/src/renderer/chat/main.css
+++ b/src/renderer/chat/main.css
@@ -1245,7 +1245,7 @@
   margin-bottom: var(--space-md);
   border-left: 3px solid var(--chat-accent);
   padding: var(--space-sm) var(--space-md);
-  background-color: #2d2d30;
+  background-color: var(--chat-bg-secondary);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 

--- a/src/renderer/chat/main.css
+++ b/src/renderer/chat/main.css
@@ -1236,3 +1236,307 @@
 .mcp-app-container[data-layout="tabs"] .mcp-panel-header {
   display: none;
 }
+
+/* ============================================
+   Agent Run Blocks
+   ============================================ */
+
+.agent-run-block {
+  margin-bottom: var(--space-md);
+  border-left: 3px solid var(--chat-accent);
+  padding: var(--space-sm) var(--space-md);
+  background-color: #2d2d30;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.agent-run-block[data-status='completed'] {
+  border-left-color: var(--chat-success);
+}
+
+.agent-run-block[data-status='error'] {
+  border-left-color: var(--chat-error);
+}
+
+.agent-run-block[data-status='aborted'] {
+  border-left-color: var(--chat-warning);
+}
+
+.agent-run-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+  font-weight: 600;
+}
+
+.agent-run-icon {
+  flex-shrink: 0;
+}
+
+.agent-run-title {
+  color: var(--chat-accent);
+  flex: 1;
+}
+
+.agent-run-model {
+  font-size: var(--font-size-xs);
+  color: var(--chat-text-muted);
+  font-weight: normal;
+}
+
+.agent-abort-btn {
+  padding: 2px 8px;
+  font-size: var(--font-size-xs);
+  background-color: var(--chat-error);
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: var(--chat-font);
+}
+
+.agent-abort-btn:hover {
+  opacity: 0.9;
+}
+
+.agent-run-task {
+  color: var(--chat-text-muted);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.agent-run-statuses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
+}
+
+.agent-status-badge {
+  font-size: var(--font-size-xs);
+  padding: 2px 6px;
+  border-radius: 3px;
+  background-color: rgba(86, 156, 214, 0.2);
+  color: var(--chat-accent);
+}
+
+.agent-run-blocks {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+/* Spinner */
+.agent-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--chat-text-muted);
+  border-top-color: var(--chat-accent);
+  border-radius: 50%;
+  animation: agent-spin 0.8s linear infinite;
+}
+
+@keyframes agent-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Text blocks */
+.agent-block-text {
+  color: var(--chat-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.6;
+}
+
+/* Thinking blocks */
+.agent-block-thinking {
+  border-left: 2px solid var(--chat-text-muted);
+  padding-left: var(--space-sm);
+}
+
+.agent-thinking-trigger {
+  background: transparent;
+  border: none;
+  color: var(--chat-text-muted);
+  cursor: pointer;
+  font-family: var(--chat-font);
+  font-size: var(--font-size-xs);
+  padding: 0;
+}
+
+.agent-thinking-trigger:hover {
+  color: var(--chat-text);
+}
+
+.agent-thinking-content {
+  color: var(--chat-text-muted);
+  font-size: var(--font-size-xs);
+  white-space: pre-wrap;
+  margin-top: var(--space-xs);
+}
+
+/* Status blocks */
+.agent-block-status {
+  color: var(--chat-text-muted);
+  font-size: var(--font-size-xs);
+  font-style: italic;
+}
+
+/* Tool blocks */
+.agent-block-tool {
+  background-color: var(--chat-bg);
+  border: 1px solid var(--chat-border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.agent-block-tool[data-status='completed'] {
+  border-color: var(--chat-success);
+}
+
+.agent-block-tool[data-status='error'] {
+  border-color: var(--chat-error);
+}
+
+.agent-tool-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--chat-bg-secondary);
+  border: none;
+  color: var(--chat-text);
+  cursor: pointer;
+  font-family: var(--chat-font);
+  font-size: var(--font-size-sm);
+}
+
+.agent-tool-trigger:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.agent-tool-name {
+  font-weight: 600;
+  color: var(--chat-accent);
+}
+
+.agent-tool-status {
+  flex-shrink: 0;
+}
+
+.agent-tool-content {
+  padding: var(--space-sm);
+  font-size: var(--font-size-xs);
+  overflow-x: auto;
+}
+
+.agent-tool-content pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--chat-string);
+}
+
+.bash-command {
+  color: var(--chat-prompt);
+  margin-bottom: var(--space-xs);
+}
+
+.edit-path,
+.read-path,
+.write-path,
+.grep-path {
+  color: var(--chat-text-muted);
+}
+
+.grep-pattern {
+  color: var(--chat-warning);
+}
+
+.read-range,
+.write-size {
+  font-size: var(--font-size-xs);
+  color: var(--chat-text-muted);
+  margin-left: var(--space-sm);
+}
+
+.tool-name-label {
+  color: var(--chat-accent);
+  font-weight: 600;
+  margin-bottom: var(--space-xs);
+}
+
+/* Truncate toggle */
+.agent-truncate-toggle {
+  background: transparent;
+  border: none;
+  color: var(--chat-accent);
+  cursor: pointer;
+  font-family: var(--chat-font);
+  font-size: var(--font-size-xs);
+  padding: var(--space-xs) 0;
+}
+
+.agent-truncate-toggle:hover {
+  text-decoration: underline;
+}
+
+/* Footer */
+.agent-run-footer {
+  margin-top: var(--space-sm);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--chat-border);
+  font-size: var(--font-size-xs);
+  color: var(--chat-text-muted);
+}
+
+/* Error */
+.agent-run-error {
+  margin-top: var(--space-sm);
+  color: var(--chat-error);
+  font-size: var(--font-size-sm);
+}
+
+/* Steer input */
+.agent-steer-input {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--chat-border);
+}
+
+.agent-steer-input input {
+  flex: 1;
+  background: var(--chat-bg);
+  color: var(--chat-text);
+  border: 1px solid var(--chat-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-sm);
+  font-family: var(--chat-font);
+  font-size: var(--font-size-xs);
+}
+
+.agent-steer-input input:focus {
+  border-color: var(--chat-accent);
+  outline: none;
+}
+
+.agent-steer-input button {
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--chat-accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: var(--chat-font);
+  font-size: var(--font-size-xs);
+}
+
+.agent-steer-input button:hover {
+  opacity: 0.9;
+}

--- a/src/renderer/chat/types/index.ts
+++ b/src/renderer/chat/types/index.ts
@@ -18,7 +18,12 @@ export interface MessageModelConfig {
   maxTurns: number;
 }
 
-export interface ChatMessage {
+/**
+ * Standard chat message (user, assistant, or system).
+ * Part of the ChatMessage discriminated union.
+ */
+export interface ChatTextMessage {
+  type: 'text';
   id: string;
   role: 'user' | 'assistant' | 'system';
   content: string;
@@ -28,6 +33,90 @@ export interface ChatMessage {
   error?: string;
   /** Model config for assistant messages - used for multi-turn continuation */
   modelConfig?: MessageModelConfig;
+}
+
+// ============================================
+// Agent Run Types
+// ============================================
+
+/** A complete or in-progress coding agent run, displayed as a single chat message */
+export interface AgentRunMessage {
+  type: 'agent-run';
+  id: string;
+  timestamp: string;
+  task: string;
+  status: 'running' | 'completed' | 'aborted' | 'error';
+  error?: string;
+  blocks: AgentBlock[];
+  title?: string;
+  statuses: Record<string, string>;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    totalCost: number;
+  };
+  model?: {
+    provider: string;
+    id: string;
+  };
+}
+
+/** A single block of agent output */
+export type AgentBlock =
+  | AgentTextBlock
+  | AgentToolBlock
+  | AgentThinkingBlock
+  | AgentStatusBlock;
+
+export interface AgentTextBlock {
+  type: 'text';
+  content: string;
+}
+
+export interface AgentToolBlock {
+  type: 'tool';
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  status: 'running' | 'completed' | 'error';
+  result?: {
+    content: unknown;
+    isError: boolean;
+  };
+}
+
+export interface AgentThinkingBlock {
+  type: 'thinking';
+  content: string;
+}
+
+export interface AgentStatusBlock {
+  type: 'status';
+  message: string;
+}
+
+/** Top-level state for the active agent run (null when no agent is running) */
+export interface AgentRunState {
+  messageId: string;
+  task: string;
+  canSteer: boolean;
+  canAbort: boolean;
+}
+
+/**
+ * Discriminated union of all chat message types.
+ * Use `message.type` to narrow: 'text' for standard messages, 'agent-run' for agent runs.
+ */
+export type ChatMessage = ChatTextMessage | AgentRunMessage;
+
+/** Type guard: is this a standard text message? */
+export function isTextMessage(msg: ChatMessage): msg is ChatTextMessage {
+  return msg.type === 'text';
+}
+
+/** Type guard: is this an agent run message? */
+export function isAgentRunMessage(msg: ChatMessage): msg is AgentRunMessage {
+  return msg.type === 'agent-run';
 }
 
 export interface ChatToolCall {
@@ -126,6 +215,8 @@ export interface ChatState {
   error: string | null;
   /** Current turn in multi-turn tool workflow (0 = first turn) */
   currentTurn: number;
+  /** Active coding agent run. Null when no agent is running. */
+  agentRun: AgentRunState | null;
 }
 
 export type ChatAction =
@@ -136,7 +227,7 @@ export type ChatAction =
   | { type: 'ADD_TO_HISTORY'; value: string }
   | { type: 'NAVIGATE_HISTORY'; direction: 'up' | 'down' }
   | { type: 'ADD_MESSAGE'; message: ChatMessage }
-  | { type: 'UPDATE_MESSAGE'; id: string; updates: Partial<ChatMessage> }
+  | { type: 'UPDATE_MESSAGE'; id: string; updates: Partial<ChatTextMessage> }
   | { type: 'APPEND_STREAM'; id: string; content: string }
   | { type: 'APPEND_TOOL_CALLS'; messageId: string; toolCalls: ChatToolCall[] }
   | { type: 'UPDATE_TOOL_CALL'; messageId: string; toolCallId: string; updates: Partial<ChatToolCall> }
@@ -150,7 +241,21 @@ export type ChatAction =
   | { type: 'CLEAR_MESSAGES' }
   | { type: 'NEW_SESSION' }
   | { type: 'INCREMENT_TURN' }
-  | { type: 'RESET_TURN' };
+  | { type: 'RESET_TURN' }
+  // --- Agent Run Lifecycle ---
+  | { type: 'AGENT_RUN_START'; task: string; messageId: string; model?: { provider: string; id: string } }
+  | { type: 'AGENT_RUN_COMPLETE'; messageId: string; usage?: AgentRunMessage['usage'] }
+  | { type: 'AGENT_RUN_ERROR'; messageId: string; error: string }
+  | { type: 'AGENT_RUN_ABORT'; messageId: string }
+  // --- Agent Run Content ---
+  | { type: 'AGENT_BLOCK_TEXT_DELTA'; messageId: string; delta: string }
+  | { type: 'AGENT_BLOCK_THINKING_DELTA'; messageId: string; delta: string }
+  | { type: 'AGENT_BLOCK_TOOL_START'; messageId: string; toolCallId: string; toolName: string; args: Record<string, unknown> }
+  | { type: 'AGENT_BLOCK_TOOL_END'; messageId: string; toolCallId: string; result: unknown; isError: boolean }
+  | { type: 'AGENT_BLOCK_STATUS'; messageId: string; message: string }
+  // --- Agent Run Metadata ---
+  | { type: 'AGENT_SET_STATUS'; messageId: string; statusKey: string; statusText: string | undefined }
+  | { type: 'AGENT_SET_TITLE'; messageId: string; title: string };
 
 // ============================================
 // Theme Types

--- a/src/renderer/chat/types/index.ts
+++ b/src/renderer/chat/types/index.ts
@@ -70,6 +70,7 @@ export type AgentBlock =
 
 export interface AgentTextBlock {
   type: 'text';
+  id: string;
   content: string;
 }
 
@@ -87,11 +88,13 @@ export interface AgentToolBlock {
 
 export interface AgentThinkingBlock {
   type: 'thinking';
+  id: string;
   content: string;
 }
 
 export interface AgentStatusBlock {
   type: 'status';
+  id: string;
   message: string;
 }
 

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -157,6 +157,31 @@ export const CONFIRM_MCPB_INSTALL = 'mcpb:confirm-install';
 export const BROWSE_PATH = 'mcpb:browse-path';
 
 // ============================================
+// Coding Agent Channels
+// ============================================
+
+/** Start the coding agent process */
+export const AGENT_START = 'agent:start';
+
+/** Execute a coding task */
+export const AGENT_EXECUTE = 'agent:execute';
+
+/** Steer the agent mid-run */
+export const AGENT_STEER = 'agent:steer';
+
+/** Abort the current agent task */
+export const AGENT_ABORT = 'agent:abort';
+
+/** Stop the agent process entirely */
+export const AGENT_STOP = 'agent:stop';
+
+/** Respond to an extension UI request from the agent */
+export const AGENT_UI_RESPONSE = 'agent:ui-response';
+
+/** Streaming agent events (main → renderer) */
+export const AGENT_EVENT = 'agent:event';
+
+// ============================================
 // Settings Channels
 // ============================================
 
@@ -218,6 +243,13 @@ export const INVOKE_CHANNELS = [
   GET_MCPB_PREVIEW_DATA,
   CONFIRM_MCPB_INSTALL,
   BROWSE_PATH,
+  // Coding agent
+  AGENT_START,
+  AGENT_EXECUTE,
+  AGENT_STEER,
+  AGENT_ABORT,
+  AGENT_STOP,
+  AGENT_UI_RESPONSE,
 ] as const;
 
 /** Channels that renderer can listen to (main → renderer events) */
@@ -234,6 +266,8 @@ export const ON_CHANNELS = [
   ON_SERVER_CRASHED,
   ON_SERVER_RESTARTING,
   ON_MANAGER_READY,
+  // Coding agent events
+  AGENT_EVENT,
 ] as const;
 
 export type InvokeChannel = (typeof INVOKE_CHANNELS)[number];


### PR DESCRIPTION
## Summary

- Integrates the [pi coding agent](https://github.com/mariozechner/pi) as an autonomous subprocess (`--mode rpc`, JSONL over stdin/stdout) that streams events back to the chat UI
- Agent runs are a first-class message type with block-based content rendering (text, tool calls, thinking, status interleaved as produced)
- ChatMessage refactored from a single interface to a discriminated union (`ChatTextMessage | AgentRunMessage`) with type guards
- `/code <task>` slash command triggers agent handoff (follows existing `/dream` pattern)

### New files
- `src/electron/main/coding-agent/` — Adapter interface, pi RPC implementation, IPC handlers
- `src/renderer/chat/components/AgentRunBlock.tsx` — Agent run renderer with tool-specific views for 7 built-in tools + generic fallback for dynamic tools
- `src/renderer/chat/hooks/useCodingAgent.ts` — React hook bridging IPC events to reducer dispatch

### Modified files
- `src/shared/channels.ts` — 7 new AGENT_* IPC channels
- `src/renderer/chat/types/index.ts` — Discriminated union, agent block types, 13 new reducer actions
- `src/renderer/chat/context/ChatContext.tsx` — Agent reducer cases, `/code` command, union-safe message loops
- `src/electron/preload/host.ts` — `codingAgent` namespace on electronAPI
- `src/electron/main/index.ts` — Agent handler registration + shutdown cleanup
- Components updated to handle the ChatMessage union

### Plan verification
Original integration plan was verified against pi-mono v0.57.1 (~150 commits since plan was written). Six updates applied:
1. Tool names use `string` not union (pi now has 7 tools + dynamic registration)
2. Auto-compaction events handle new `reason`, `aborted`, `willRetry` fields
3. Auto-retry handles both `start` and `end` events
4. New extension UI methods (`setStatus`, `setTitle`, `setWidget`)
5. Extension UI responses properly typed
6. Provider/model use text inputs (pi's provider list continues to grow)

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npx vite build` passes (verified)
- [ ] Electron app starts without errors (`npm run electron:dev`)
- [ ] `/code hello world` dispatches AGENT_RUN_START and shows AgentRunBlock in chat
- [ ] With pi installed: agent events stream and render (text, tool calls, status)
- [ ] Steer input sends message to running agent
- [ ] Abort button stops agent and shows aborted state
- [ ] App quit gracefully shuts down pi subprocess

🤖 Generated with [Claude Code](https://claude.com/claude-code)